### PR TITLE
enh: replace local input file copy with S3 ranged gets

### DIFF
--- a/internal/apiserver/file/file_handler_test.go
+++ b/internal/apiserver/file/file_handler_test.go
@@ -154,6 +154,10 @@ func (c *errStoreFileClient) Retrieve(ctx context.Context, fileName, folderName 
 	return nil, nil, errors.New("not implemented")
 }
 
+func (c *errStoreFileClient) RetrieveRange(_ context.Context, _, _ string, _ int64, _ int64) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (c *errStoreFileClient) Delete(ctx context.Context, fileName, folderName string) error {
 	return nil
 }

--- a/internal/files_store/api/files.go
+++ b/internal/files_store/api/files.go
@@ -52,6 +52,9 @@ type BatchFilesClient interface {
 	// Retrieve retrieves a file from the files storage.
 	Retrieve(ctx context.Context, fileName, folderName string) (reader io.ReadCloser, fileMd *BatchFileMetadata, err error)
 
+	// RetrieveRange retrieves a byte range [offset, offset+length) from a file in storage.
+	RetrieveRange(ctx context.Context, fileName, folderName string, offset int64, length int64) (io.ReadCloser, error)
+
 	// Delete deletes the file in the specified location.
 	Delete(ctx context.Context, fileName, folderName string) (err error)
 }

--- a/internal/files_store/fs/client.go
+++ b/internal/files_store/fs/client.go
@@ -18,6 +18,7 @@ limitations under the License.
 package fs
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -211,6 +212,32 @@ func (c *Client) Retrieve(ctx context.Context, fileName, folderName string) (io.
 		"path", relPath, "size", metadata.Size)
 
 	return file, metadata, nil
+}
+
+// RetrieveRange retrieves a byte range [offset, offset+length) from a file in the filesystem.
+func (c *Client) RetrieveRange(ctx context.Context, fileName, folderName string, offset int64, length int64) (io.ReadCloser, error) {
+	relPath, err := c.resolvePath(folderName, fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := c.root.Open(relPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	buf := make([]byte, length)
+	n, err := file.ReadAt(buf, offset)
+	if err != nil && (err != io.EOF || int64(n) != length) {
+		return nil, fmt.Errorf("read range at offset %d length %d: %w", offset, length, err)
+	}
+	buf = buf[:n]
+
+	logr.FromContextOrDiscard(ctx).V(logging.TRACE).Info("Range retrieved",
+		"path", relPath, "offset", offset, "length", length)
+
+	return io.NopCloser(bytes.NewReader(buf)), nil
 }
 
 // Delete deletes a file from the filesystem.

--- a/internal/files_store/fs/client_test.go
+++ b/internal/files_store/fs/client_test.go
@@ -276,6 +276,41 @@ func TestRetrieve(t *testing.T) {
 
 }
 
+func TestRetrieveRange(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("retrieves byte range", func(t *testing.T) {
+		client := newTestClient(t)
+		content := []byte("hello world range test")
+
+		if _, err := client.Store(ctx, "range.txt", testFolder, 1024, 0, bytes.NewReader(content)); err != nil {
+			t.Fatalf("failed to store: %v", err)
+		}
+
+		rc, err := client.RetrieveRange(ctx, "range.txt", testFolder, 6, 5)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		defer rc.Close()
+
+		data, _ := io.ReadAll(rc)
+		if string(data) != "world" {
+			t.Errorf("expected %q, got %q", "world", string(data))
+		}
+	})
+
+	t.Run("returns error for non-existent file", func(t *testing.T) {
+		client := newTestClient(t)
+
+		_, err := client.RetrieveRange(ctx, "nonexistent.txt", testFolder, 0, 10)
+		if err != nil {
+			// Expect an error (file not found).
+			return
+		}
+		t.Error("expected error for non-existent file")
+	})
+}
+
 func TestDelete(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/files_store/mock/mock_files_client.go
+++ b/internal/files_store/mock/mock_files_client.go
@@ -145,7 +145,10 @@ func (m *MockBatchFilesClient) Retrieve(ctx context.Context, fileName, folderNam
 }
 
 // RetrieveRange retrieves a byte range [offset, offset+length) from a file.
-func (m *MockBatchFilesClient) RetrieveRange(_ context.Context, fileName, folderName string, offset int64, length int64) (io.ReadCloser, error) {
+func (m *MockBatchFilesClient) RetrieveRange(ctx context.Context, fileName, folderName string, offset int64, length int64) (io.ReadCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	filePath := filepath.Join(m.rootDir, folderName, fileName)
 
 	file, err := os.Open(filePath)

--- a/internal/files_store/mock/mock_files_client.go
+++ b/internal/files_store/mock/mock_files_client.go
@@ -19,6 +19,7 @@ package mock
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -141,6 +142,26 @@ func (m *MockBatchFilesClient) Retrieve(ctx context.Context, fileName, folderNam
 		Size:     fileInfo.Size(),
 		ModTime:  fileInfo.ModTime(),
 	}, nil
+}
+
+// RetrieveRange retrieves a byte range [offset, offset+length) from a file.
+func (m *MockBatchFilesClient) RetrieveRange(_ context.Context, fileName, folderName string, offset int64, length int64) (io.ReadCloser, error) {
+	filePath := filepath.Join(m.rootDir, folderName, fileName)
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	buf := make([]byte, length)
+	n, err := file.ReadAt(buf, offset)
+	if err != nil && (err != io.EOF || int64(n) != length) {
+		return nil, fmt.Errorf("failed to read range at offset %d length %d: %w", offset, length, err)
+	}
+	buf = buf[:n]
+
+	return io.NopCloser(bytes.NewReader(buf)), nil
 }
 
 // List lists the files in the specified location.

--- a/internal/files_store/retryclient/client.go
+++ b/internal/files_store/retryclient/client.go
@@ -115,6 +115,33 @@ func (c *Client) Retrieve(ctx context.Context, fileName, folderName string) (io.
 	return rc, meta, err
 }
 
+func (c *Client) RetrieveRange(ctx context.Context, fileName, folderName string, offset int64, length int64) (io.ReadCloser, error) {
+	var rc io.ReadCloser
+	attempts, err := retry.Do(ctx, &c.cfg, func(attempt int) error {
+		if attempt > 1 {
+			if rc != nil {
+				_ = rc.Close()
+			}
+			recordRetry("retrieve_range", c.component)
+			logr.FromContextOrDiscard(ctx).Info("Retrying file retrieve range",
+				"file", fileName, "offset", offset, "length", length,
+				"attempt", attempt, "maxRetries", c.cfg.MaxRetries)
+		}
+
+		var retrieveErr error
+		rc, retrieveErr = c.inner.RetrieveRange(ctx, fileName, folderName, offset, length)
+		return retrieveErr
+	})
+	if err != nil {
+		if attempts > c.cfg.MaxRetries {
+			recordExhausted("retrieve_range", c.component)
+		}
+	} else {
+		recordSuccess("retrieve_range", c.component)
+	}
+	return rc, err
+}
+
 func (c *Client) Delete(ctx context.Context, fileName, folderName string) error {
 	attempts, err := retry.Do(ctx, &c.cfg, func(attempt int) error {
 		if attempt > 1 {

--- a/internal/files_store/retryclient/client_test.go
+++ b/internal/files_store/retryclient/client_test.go
@@ -63,6 +63,14 @@ func (m *mockFilesClient) Delete(_ context.Context, _, _ string) error {
 	return nil
 }
 
+func (m *mockFilesClient) RetrieveRange(_ context.Context, _, _ string, _ int64, _ int64) (io.ReadCloser, error) {
+	m.retrieveCalls++
+	if m.retrieveCalls <= m.failUntil {
+		return nil, errors.New("transient retrieve range error")
+	}
+	return io.NopCloser(bytes.NewReader([]byte("data"))), nil
+}
+
 func (m *mockFilesClient) Close() error { return nil }
 
 func retryCfg() retry.Config {
@@ -190,6 +198,24 @@ func TestRetrieve_SucceedsAfterRetry(t *testing.T) {
 	defer rc.Close()
 	if meta.Size != 4 {
 		t.Fatalf("expected size 4, got %d", meta.Size)
+	}
+	if mock.retrieveCalls != 2 {
+		t.Fatalf("expected 2 retrieve calls, got %d", mock.retrieveCalls)
+	}
+}
+
+func TestRetrieveRange_SucceedsAfterRetry(t *testing.T) {
+	mock := &mockFilesClient{failUntil: 1}
+	c := New(mock, retryCfg(), "test")
+
+	rc, err := c.RetrieveRange(context.Background(), "f.txt", "folder", 0, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer rc.Close()
+	data, _ := io.ReadAll(rc)
+	if string(data) != "data" {
+		t.Fatalf("expected %q, got %q", "data", string(data))
 	}
 	if mock.retrieveCalls != 2 {
 		t.Fatalf("expected 2 retrieve calls, got %d", mock.retrieveCalls)

--- a/internal/files_store/s3/client.go
+++ b/internal/files_store/s3/client.go
@@ -274,6 +274,31 @@ func (c *Client) Retrieve(ctx context.Context, fileName, folderName string) (io.
 	return out.Body, metadata, nil
 }
 
+// RetrieveRange retrieves a byte range [offset, offset+length) from a file in S3.
+func (c *Client) RetrieveRange(ctx context.Context, fileName, folderName string, offset int64, length int64) (io.ReadCloser, error) {
+	key := c.buildKey(folderName, fileName)
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", offset, offset+length-1)
+
+	out, err := c.s3Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(c.bucket),
+		Key:    aws.String(key),
+		Range:  aws.String(rangeHeader),
+	})
+	if err != nil {
+		var noSuchKey *types.NoSuchKey
+		var noSuchBucket *types.NoSuchBucket
+		if errors.As(err, &noSuchKey) || errors.As(err, &noSuchBucket) {
+			return nil, os.ErrNotExist
+		}
+		return nil, err
+	}
+
+	logr.FromContextOrDiscard(ctx).V(logging.TRACE).Info("Range retrieved",
+		"bucket", c.bucket, "key", key, "offset", offset, "length", length)
+
+	return out.Body, nil
+}
+
 // Delete deletes a file from S3.
 // The folderName parameter is used as a key prefix for tenant isolation.
 func (c *Client) Delete(ctx context.Context, fileName, folderName string) error {

--- a/internal/files_store/s3/client_test.go
+++ b/internal/files_store/s3/client_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -98,9 +99,20 @@ func (m *mockS3Client) GetObject(_ context.Context, params *s3.GetObjectInput, _
 	if !ok {
 		return nil, &types.NoSuchKey{}
 	}
+	data := obj.data
+	if params.Range != nil {
+		// Parse "bytes=start-end" range header.
+		var start, end int64
+		if _, err := fmt.Sscanf(*params.Range, "bytes=%d-%d", &start, &end); err == nil {
+			if end >= int64(len(data)) {
+				end = int64(len(data)) - 1
+			}
+			data = data[start : end+1]
+		}
+	}
 	return &s3.GetObjectOutput{
-		Body:          io.NopCloser(bytes.NewReader(obj.data)),
-		ContentLength: aws.Int64(int64(len(obj.data))),
+		Body:          io.NopCloser(bytes.NewReader(data)),
+		ContentLength: aws.Int64(int64(len(data))),
 		LastModified:  aws.Time(obj.lastModTime),
 	}, nil
 }
@@ -331,6 +343,41 @@ func TestRetrieve(t *testing.T) {
 		client := newTestClient(mock)
 
 		_, _, err := client.Retrieve(ctx, "nonexistent.txt", testFolderName)
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("expected os.ErrNotExist, got %v", err)
+		}
+	})
+}
+
+func TestRetrieveRange(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("retrieves byte range", func(t *testing.T) {
+		mock := newMockS3Client()
+		client := newTestClient(mock)
+		content := []byte("hello world range test")
+
+		if _, err := client.Store(ctx, "range.txt", testBucketName, 1024, 0, bytes.NewReader(content)); err != nil {
+			t.Fatalf("failed to store: %v", err)
+		}
+
+		rc, err := client.RetrieveRange(ctx, "range.txt", testBucketName, 6, 5)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		defer rc.Close()
+
+		data, _ := io.ReadAll(rc)
+		if string(data) != "world" {
+			t.Errorf("expected %q, got %q", "world", string(data))
+		}
+	})
+
+	t.Run("returns error for non-existent file", func(t *testing.T) {
+		mock := newMockS3Client()
+		client := newTestClient(mock)
+
+		_, err := client.RetrieveRange(ctx, "nonexistent.txt", testBucketName, 0, 10)
 		if !errors.Is(err, os.ErrNotExist) {
 			t.Errorf("expected os.ErrNotExist, got %v", err)
 		}

--- a/internal/files_store/tracing/tracing.go
+++ b/internal/files_store/tracing/tracing.go
@@ -105,6 +105,26 @@ func (r *tracedReadCloser) Close() error {
 	return err
 }
 
+func (c *Client) RetrieveRange(ctx context.Context, fileName, folderName string, offset int64, length int64) (io.ReadCloser, error) {
+	_, span := uotel.StartSpan(ctx, "storage.RetrieveRange")
+	span.SetAttributes(
+		c.backend,
+		attribute.String("storage.file_name", fileName),
+		attribute.String("storage.folder", folderName),
+		attribute.Int64("storage.offset", offset),
+		attribute.Int64("storage.length", length),
+	)
+
+	reader, err := c.inner.RetrieveRange(ctx, fileName, folderName, offset, length)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "retrieve range failed")
+		span.End()
+		return nil, err
+	}
+	return &tracedReadCloser{ReadCloser: reader, span: span}, nil
+}
+
 func (c *Client) Delete(ctx context.Context, fileName, folderName string) error {
 	ctx, span := uotel.StartSpan(ctx, "storage.Delete")
 	defer span.End()

--- a/internal/processor/worker/execute_pipeline.go
+++ b/internal/processor/worker/execute_pipeline.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
 
+	filesapi "github.com/llm-d/llm-d-batch-gateway/internal/files_store/api"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/pipeline"
@@ -48,6 +50,29 @@ func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionPar
 		sloDeadline = params.task.SLO
 	}
 
+	var (
+		inputRef  *inputFileRef
+		inputFile *os.File
+	)
+	if params.jobInfo != nil && params.jobInfo.BatchJob != nil && params.jobInfo.BatchJob.InputFileID != "" {
+		ref, err := p.resolveInputFileCoords(ctx, params.jobInfo.BatchJob.InputFileID)
+		if err != nil {
+			return nil, fmt.Errorf("resolve input file coordinates: %w", err)
+		}
+		inputRef = ref
+	} else {
+		localInputPath := filepath.Join(jobRootDir, "input.jsonl")
+		if f, err := os.Open(localInputPath); err == nil {
+			inputFile = f
+			defer inputFile.Close()
+		}
+	}
+
+	var storage filesapi.BatchFilesClient
+	if p.files != nil {
+		storage = p.files.storage
+	}
+
 	// Setup pipeline.
 
 	tracker := pipeline.NewProgressTracker(
@@ -60,7 +85,9 @@ func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionPar
 	tracker.AddFailed(modelMap.RejectedCount)
 
 	source := NewPlanFileSource(PlanFileSourceConfig{
-		InputFile:          files.input,
+		Storage:            storage,
+		InputRef:           inputRef,
+		InputFile:          inputFile,
 		PlansDir:           plansDir,
 		ModelMap:           modelMap,
 		Resolver:           p.inference,
@@ -152,11 +179,11 @@ func (p *Processor) buildRequestDispatcher(modelMap *modelMapFile, pending *pipe
 }
 
 type dataFiles struct {
-	input, output, error *os.File
+	output, error *os.File
 }
 
 func (f *dataFiles) close() {
-	for _, file := range []*os.File{f.input, f.output, f.error} {
+	for _, file := range []*os.File{f.output, f.error} {
 		if file != nil {
 			_ = file.Close()
 		}
@@ -167,40 +194,27 @@ func (p *Processor) openDataFiles(params *jobExecutionParams) (*dataFiles, error
 	jobID := params.jobInfo.JobID
 	tenantID := params.jobInfo.TenantID
 
-	inputPath, err := p.jobInputFilePath(jobID, tenantID)
-	if err != nil {
-		return nil, err
-	}
-	inputFile, err := os.Open(inputPath)
-	if err != nil {
-		return nil, fmt.Errorf("open input file: %w", err)
-	}
-
 	outputPath, err := p.jobOutputFilePath(jobID, tenantID)
 	if err != nil {
-		inputFile.Close()
 		return nil, err
 	}
 	outputFile, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
-		inputFile.Close()
 		return nil, fmt.Errorf("create output file: %w", err)
 	}
 
 	errorPath, err := p.jobErrorFilePath(jobID, tenantID)
 	if err != nil {
-		inputFile.Close()
 		outputFile.Close()
 		return nil, err
 	}
 	errorFile, err := os.OpenFile(errorPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
-		inputFile.Close()
 		outputFile.Close()
 		return nil, fmt.Errorf("create error file: %w", err)
 	}
 
-	return &dataFiles{input: inputFile, output: outputFile, error: errorFile}, nil
+	return &dataFiles{output: outputFile, error: errorFile}, nil
 }
 
 // buildAIMDModels keys per-endpoint concurrency state by route key: dispatch

--- a/internal/processor/worker/fileio.go
+++ b/internal/processor/worker/fileio.go
@@ -37,7 +37,6 @@ const (
 	plansDirName = "plans"
 
 	// local job artifact file names
-	inputFileName  = "input.jsonl"
 	outputFileName = "output.jsonl"
 	errorFileName  = "error.jsonl"
 
@@ -46,20 +45,19 @@ const (
 	errorStorageNameFmt  = "batch_error_%s.jsonl"
 )
 
+// inputFileRef identifies an input file in shared storage.
+// Resolved once per job from the input file's DB record.
+type inputFileRef struct {
+	storageName string
+	folderName  string
+}
+
 func (p *Processor) jobRootDir(jobID, tenantID string) (string, error) {
 	folderName, err := ucom.GetFolderNameByTenantID(tenantID)
 	if err != nil {
 		return "", fmt.Errorf("failed to sanitize tenant id for job path: %w", err)
 	}
 	return filepath.Join(p.cfg.WorkDir, folderName, jobsDirName, jobID), nil
-}
-
-func (p *Processor) jobInputFilePath(jobID, tenantID string) (string, error) {
-	jobRootDir, err := p.jobRootDir(jobID, tenantID)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(jobRootDir, inputFileName), nil
 }
 
 func (p *Processor) jobOutputFilePath(jobID, tenantID string) (string, error) {
@@ -96,20 +94,6 @@ func (p *Processor) jobPlansDir(jobID, tenantID string) (string, error) {
 	return filepath.Join(jobRootDir, plansDirName), nil
 }
 
-// createLocalInputFile creates or truncates the local input file for a job.
-func (p *Processor) createLocalInputFile(jobID, tenantID string) (*os.File, string, error) {
-	localInputFilePath, err := p.jobInputFilePath(jobID, tenantID)
-	if err != nil {
-		return nil, "", err
-	}
-
-	localInputFile, err := os.OpenFile(localInputFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return nil, localInputFilePath, fmt.Errorf("failed to create local input file: %w", err)
-	}
-	return localInputFile, localInputFilePath, nil
-}
-
 // cleanupJobArtifacts removes the local job artifacts directory as best-effort.
 func (p *Processor) cleanupJobArtifacts(ctx context.Context, jobID, tenantID string) {
 	logger := logr.FromContextOrDiscard(ctx)
@@ -127,31 +111,40 @@ func (p *Processor) cleanupJobArtifacts(ctx context.Context, jobID, tenantID str
 	logger.V(logging.INFO).Info("Removed job directory", "path", jobDir)
 }
 
-// openInputFileStream opens the input file stream
-func (p *Processor) openInputFileStream(ctx context.Context, inputFileID string) (io.ReadCloser, *filesapi.BatchFileMetadata, error) {
-	// get file metadata from database
+// resolveInputFileCoords looks up the storage name and folder for an input file ID.
+func (p *Processor) resolveInputFileCoords(ctx context.Context, inputFileID string) (*inputFileRef, error) {
 	items, _, _, err := p.files.db.DBGet(ctx, &db.FileQuery{BaseQuery: db.BaseQuery{IDs: []string{inputFileID}}}, true, 0, 1)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get input file metadata: %w", err)
+		return nil, fmt.Errorf("failed to get input file metadata: %w", err)
 	}
 	if len(items) == 0 {
-		return nil, nil, fmt.Errorf("input file %q not found in db", inputFileID)
+		return nil, fmt.Errorf("input file %q not found in db", inputFileID)
 	}
 
-	// convert file db item to file object
 	fileItem := items[0]
 	fileObj, err := converter.DBItemToFile(fileItem)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to convert file db item to file: %w", err)
+		return nil, fmt.Errorf("failed to convert file db item to file: %w", err)
 	}
 
-	// retrieve input jsonl file from storage
 	folderName, err := ucom.GetFolderNameByTenantID(fileItem.TenantID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get folder name by tenant id: %w", err)
+		return nil, fmt.Errorf("failed to get folder name by tenant id: %w", err)
 	}
-	storageName := ucom.FileStorageName(fileItem.ID, fileObj.Filename)
-	reader, metadata, err := p.files.storage.Retrieve(ctx, storageName, folderName)
+
+	return &inputFileRef{
+		storageName: ucom.FileStorageName(fileItem.ID, fileObj.Filename),
+		folderName:  folderName,
+	}, nil
+}
+
+// openInputFileStream opens the input file stream from shared storage.
+func (p *Processor) openInputFileStream(ctx context.Context, inputFileID string) (io.ReadCloser, *filesapi.BatchFileMetadata, error) {
+	ref, err := p.resolveInputFileCoords(ctx, inputFileID)
+	if err != nil {
+		return nil, nil, err
+	}
+	reader, metadata, err := p.files.storage.Retrieve(ctx, ref.storageName, ref.folderName)
 	if err != nil {
 		return nil, metadata, fmt.Errorf("failed to open input file stream: %w", err)
 	}

--- a/internal/processor/worker/fileio_test.go
+++ b/internal/processor/worker/fileio_test.go
@@ -14,26 +14,3 @@ func TestJobRootDir_EmptyTenantID_ReturnsError(t *testing.T) {
 		t.Fatalf("expected error for empty tenantID")
 	}
 }
-
-func TestJobInputFilePath_PropagatesJobRootDirError(t *testing.T) {
-	p := mustNewProcessor(t, config.NewConfig(), &clientset.Clientset{})
-
-	if _, err := p.jobInputFilePath("job-1", ""); err == nil {
-		t.Fatalf("expected error from jobRootDir when tenantID is empty")
-	}
-}
-
-func TestCreateLocalInputFile_PropagatesPathError(t *testing.T) {
-	p := mustNewProcessor(t, config.NewConfig(), &clientset.Clientset{})
-
-	f, path, err := p.createLocalInputFile("job-1", "")
-	if err == nil {
-		t.Fatalf("expected error for empty tenantID")
-	}
-	if f != nil {
-		t.Fatalf("expected nil file on error")
-	}
-	if path != "" {
-		t.Fatalf("expected empty path on path-resolution error, got %q", path)
-	}
-}

--- a/internal/processor/worker/finalizer_test.go
+++ b/internal/processor/worker/finalizer_test.go
@@ -660,6 +660,9 @@ func (c *concurrentFilesClient) Retrieve(_ context.Context, _, _ string) (io.Rea
 func (c *concurrentFilesClient) List(_ context.Context, _ string) ([]filesapi.BatchFileMetadata, error) {
 	return nil, nil
 }
+func (c *concurrentFilesClient) RetrieveRange(_ context.Context, _, _ string, _ int64, _ int64) (io.ReadCloser, error) {
+	return nil, nil
+}
 func (c *concurrentFilesClient) Delete(_ context.Context, _, _ string) error { return nil }
 func (c *concurrentFilesClient) GetContext(p context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithCancel(p)

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -91,15 +91,6 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 		logger.V(logging.INFO).Info("Input file metadata", "metadata", metadata)
 	}
 
-	// create local input file
-	localInputFile, localInputFilePath, err := p.createLocalInputFile(jobID, jobInfo.TenantID)
-	if err != nil {
-		return fmt.Errorf("create local input file: %w", err)
-	}
-	defer localInputFile.Close()
-
-	writer := bufio.NewWriterSize(localInputFile, 1024*1024)
-
 	acc := newPlanAccumulator(jobRootDir)
 
 	// model intern tables
@@ -151,7 +142,7 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 		}
 
 		// read a line from the input file
-		line, done, err := readNormalizedLine(inputFileReader)
+		line, streamBytes, done, err := readNormalizedLine(inputFileReader)
 		if err != nil {
 			return fmt.Errorf("read line %d from input file: %w", lineCount+1, err)
 		}
@@ -160,11 +151,6 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 		}
 
 		lineCount++
-
-		// write the line to the input file.
-		if _, err := writer.Write(line); err != nil {
-			return fmt.Errorf("write line %d to input file %q: %w", lineCount, localInputFilePath, err)
-		}
 
 		requestMeta, err := extractAndValidateLine(line)
 		if err != nil {
@@ -211,20 +197,15 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 				metrics.RecordRequestError(lookupID)
 				logger.V(logging.DEBUG).Info("Rejected request for unregistered model",
 					"customId", requestMeta.CustomID, "model", requestMeta.ModelID)
-				offset += int64(len(line))
+				offset += int64(streamBytes)
 				continue
 			}
 		}
 
 		nextOffset := accumulatePlanEntry(
-			acc, requestMeta.ModelID, modelToSafe, used, offset, uint32(len(line)), requestMeta.PrefixHash,
+			acc, requestMeta.ModelID, modelToSafe, used, offset, uint32(streamBytes), requestMeta.PrefixHash,
 		)
 		offset = nextOffset
-	}
-
-	// flush input.jsonl file
-	if err := writer.Flush(); err != nil {
-		return fmt.Errorf("flush input file %q: %w", localInputFilePath, err)
 	}
 
 	if err := finalizePlanFiles(acc, modelToSafe); err != nil {
@@ -251,27 +232,28 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 		modelCounts[model] = len(acc.entries[safe])
 	}
 	logger.V(logging.INFO).Info("Processor Pre-processing job completed",
-		"inputFilePath", localInputFilePath, "planFilePath", acc.plansDir(),
+		"planFilePath", acc.plansDir(),
 		"lineCount", lineCount, "rejected", rejectedCount, "models", modelCounts)
 
 	return nil
 }
 
 // readNormalizedLine reads the next line from the reader, ensuring it ends with '\n'.
-// Returns (line, eof, err): line is the normalized bytes, eof is true when input is exhausted.
-func readNormalizedLine(r *bufio.Reader) ([]byte, bool, error) {
-	line, err := r.ReadBytes('\n')
+// streamBytes is the number of bytes consumed from the underlying stream (may differ from
+// len(line) for the last line in a file that has no trailing newline).
+func readNormalizedLine(r *bufio.Reader) (line []byte, streamBytes int, done bool, err error) {
+	line, err = r.ReadBytes('\n')
 	if err != nil && err != io.EOF {
-		return nil, false, err
+		return nil, 0, false, err
 	}
 	if len(line) == 0 && err == io.EOF {
-		return nil, true, nil
+		return nil, 0, true, nil
 	}
-	// if last line is not terminated with '\n', append '\n' to the line
+	streamBytes = len(line)
 	if line[len(line)-1] != '\n' {
 		line = append(line, '\n')
 	}
-	return line, false, nil
+	return line, streamBytes, false, nil
 }
 
 type requestMeta struct {

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -26,8 +26,7 @@ import (
 
 // -------------------------
 // Test 1: Ingestion
-// - local input.jsonl exact copy (line-by-line)
-// - plan offsets/lengths are correct (ReadAt matches original line bytes)
+// - plan offsets/lengths are correct (match remote input bytes)
 // - model_map.json consistency
 // -------------------------
 
@@ -107,20 +106,7 @@ func TestPreProcess_BuildsPlansAndModelMap_OffsetsCorrect(t *testing.T) {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
-	// 1) local input exists and equals remoteBuf
-	localInput, err := p.jobInputFilePath(jobID, tenantID)
-	if err != nil {
-		t.Fatalf("jobInputFilePath: %v", err)
-	}
-	gotLocal, err := os.ReadFile(localInput)
-	if err != nil {
-		t.Fatalf("read local input: %v", err)
-	}
-	if !bytes.Equal(gotLocal, remoteBuf.Bytes()) {
-		t.Fatalf("local input != remote input (bytes differ)")
-	}
-
-	// 2) model_map.json exists and is consistent
+	// 1) model_map.json exists and is consistent
 	jobRootDir, err := p.jobRootDir(jobID, tenantID)
 	if err != nil {
 		t.Fatalf("jobRootDir: %v", err)
@@ -146,12 +132,8 @@ func TestPreProcess_BuildsPlansAndModelMap_OffsetsCorrect(t *testing.T) {
 		}
 	}
 
-	// 3) plan files exist and offsets/length map back to exact original line bytes (ReadAt)
-	f, err := os.Open(localInput)
-	if err != nil {
-		t.Fatalf("open local input for ReadAt: %v", err)
-	}
-	defer f.Close()
+	// 2) plan files exist and offsets/length map back to exact original line bytes
+	remoteInput := remoteBuf.Bytes()
 
 	plansDir := filepath.Join(jobRootDir, "plans")
 	for safeID := range mm.SafeToModel {
@@ -161,9 +143,13 @@ func TestPreProcess_BuildsPlansAndModelMap_OffsetsCorrect(t *testing.T) {
 		}
 		entries := testReadPlanEntries(t, planPath)
 
-		// For each entry, read input.jsonl slice and ensure it is a valid JSON line ending with '\n'
+		// For each entry, verify offset/length against the remote input buffer
 		for _, e := range entries {
-			chunk := readAtExact(t, f, e.Offset, e.Length)
+			end := int64(e.Offset) + int64(e.Length)
+			if end > int64(len(remoteInput)) {
+				t.Fatalf("entry out of bounds: safeID=%q off=%d len=%d remoteLen=%d", safeID, e.Offset, e.Length, len(remoteInput))
+			}
+			chunk := remoteInput[e.Offset:end]
 			if len(chunk) == 0 || chunk[len(chunk)-1] != '\n' {
 				t.Fatalf("entry does not end with newline: safeID=%q off=%d len=%d", safeID, e.Offset, e.Length)
 			}
@@ -274,20 +260,14 @@ func TestPreProcess_SystemPrompts_PrefixHashAndSortOrder(t *testing.T) {
 	}
 
 	// Collect hashes to verify properties
+	remoteInput := remoteBuf.Bytes()
 	hashBySpec := make([]uint32, len(specs))
 	for i, e := range entries {
-		// Read actual line from local input to identify which spec it corresponds to
-		localInput, err := p.jobInputFilePath(jobID, tenantID)
-		if err != nil {
-			t.Fatalf("jobInputFilePath: %v", err)
+		end := int64(e.Offset) + int64(e.Length)
+		if end > int64(len(remoteInput)) {
+			t.Fatalf("entry out of bounds: off=%d len=%d remoteLen=%d", e.Offset, e.Length, len(remoteInput))
 		}
-		f, err := os.Open(localInput)
-		if err != nil {
-			t.Fatalf("open local input: %v", err)
-		}
-		chunk := readAtExact(t, f, e.Offset, e.Length)
-		f.Close()
-		_ = chunk
+		_ = remoteInput[e.Offset:end]
 		hashBySpec[i] = e.PrefixHash
 	}
 

--- a/internal/processor/worker/source_planfile.go
+++ b/internal/processor/worker/source_planfile.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 
+	filesapi "github.com/llm-d/llm-d-batch-gateway/internal/files_store/api"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/pipeline"
 	batch_types "github.com/llm-d/llm-d-batch-gateway/internal/shared/types"
@@ -22,6 +24,8 @@ import (
 
 // PlanFileSource reads plan files and input JSONL to produce RequestItems.
 type PlanFileSource struct {
+	storage            filesapi.BatchFilesClient
+	inputRef           *inputFileRef
 	inputFile          *os.File
 	plansDir           string
 	modelMap           *modelMapFile
@@ -36,6 +40,8 @@ type PlanFileSource struct {
 var _ pipeline.RequestSource = (*PlanFileSource)(nil)
 
 type PlanFileSourceConfig struct {
+	Storage            filesapi.BatchFilesClient
+	InputRef           *inputFileRef
 	InputFile          *os.File
 	PlansDir           string
 	ModelMap           *modelMapFile
@@ -49,6 +55,8 @@ type PlanFileSourceConfig struct {
 
 func NewPlanFileSource(cfg PlanFileSourceConfig) *PlanFileSource {
 	return &PlanFileSource{
+		storage:            cfg.Storage,
+		inputRef:           cfg.InputRef,
 		inputFile:          cfg.InputFile,
 		plansDir:           cfg.PlansDir,
 		modelMap:           cfg.ModelMap,
@@ -88,9 +96,27 @@ func (s *PlanFileSource) Produce(_ context.Context, outgoingRequestCh chan<- pip
 }
 
 func (s *PlanFileSource) readEntry(entry planEntry, modelID string) (*pipeline.RequestItem, error) {
-	buf := make([]byte, entry.Length)
-	if _, err := s.inputFile.ReadAt(buf, entry.Offset); err != nil {
-		return nil, fmt.Errorf("%w at offset %d: %w", errRequestInputRead, entry.Offset, err)
+	var buf []byte
+	if s.storage != nil && s.inputRef != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		rc, err := s.storage.RetrieveRange(ctx, s.inputRef.storageName, s.inputRef.folderName, entry.Offset, int64(entry.Length))
+		if err != nil {
+			return nil, fmt.Errorf("%w at offset %d: %w", errRequestInputRead, entry.Offset, err)
+		}
+		defer rc.Close()
+
+		buf, err = io.ReadAll(rc)
+		if err != nil {
+			return nil, fmt.Errorf("%w at offset %d: %w", errRequestInputRead, entry.Offset, err)
+		}
+	} else if s.inputFile != nil {
+		buf = make([]byte, entry.Length)
+		if _, err := s.inputFile.ReadAt(buf, entry.Offset); err != nil {
+			return nil, fmt.Errorf("%w at offset %d: %w", errRequestInputRead, entry.Offset, err)
+		}
+	} else {
+		return nil, fmt.Errorf("%w: no storage or input file provided", errRequestInputRead)
 	}
 
 	trimmed := bytes.TrimSuffix(buf, []byte{'\n'})

--- a/internal/processor/worker/source_planfile.go
+++ b/internal/processor/worker/source_planfile.go
@@ -69,11 +69,10 @@ func NewPlanFileSource(cfg PlanFileSourceConfig) *PlanFileSource {
 	}
 }
 
-// Produce sends one item per plan entry to the channel. It always reads the
-// input line so each item retains the original custom_id: cancel / expire
-// drain still needs that identity in the error file even when inference is
-// skipped. Context cancellation is handled by the dispatcher drain path.
-func (s *PlanFileSource) Produce(_ context.Context, outgoingRequestCh chan<- pipeline.RequestItem) error {
+// Produce sends one item per plan entry to the channel. It reads the input
+// line so each item retains the original custom_id. Context cancellation is
+// respected during storage reads and channel sends.
+func (s *PlanFileSource) Produce(ctx context.Context, outgoingRequestCh chan<- pipeline.RequestItem) error {
 	defer close(outgoingRequestCh)
 
 	for safeModelID, modelID := range s.modelMap.SafeToModel {
@@ -84,7 +83,7 @@ func (s *PlanFileSource) Produce(_ context.Context, outgoingRequestCh chan<- pip
 		}
 
 		for _, entry := range entries {
-			item, err := s.readEntry(entry, modelID)
+			item, err := s.readEntry(ctx, entry, modelID)
 			if err != nil {
 				return err
 			}
@@ -95,19 +94,25 @@ func (s *PlanFileSource) Produce(_ context.Context, outgoingRequestCh chan<- pip
 	return nil
 }
 
-func (s *PlanFileSource) readEntry(entry planEntry, modelID string) (*pipeline.RequestItem, error) {
+func (s *PlanFileSource) readEntry(ctx context.Context, entry planEntry, modelID string) (*pipeline.RequestItem, error) {
 	var buf []byte
 	if s.storage != nil && s.inputRef != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		rc, err := s.storage.RetrieveRange(ctx, s.inputRef.storageName, s.inputRef.folderName, entry.Offset, int64(entry.Length))
+		rc, err := s.storage.RetrieveRange(reqCtx, s.inputRef.storageName, s.inputRef.folderName, entry.Offset, int64(entry.Length))
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			return nil, fmt.Errorf("%w at offset %d: %w", errRequestInputRead, entry.Offset, err)
 		}
 		defer rc.Close()
 
 		buf, err = io.ReadAll(rc)
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			return nil, fmt.Errorf("%w at offset %d: %w", errRequestInputRead, entry.Offset, err)
 		}
 	} else if s.inputFile != nil {

--- a/internal/processor/worker/source_planfile.go
+++ b/internal/processor/worker/source_planfile.go
@@ -69,10 +69,12 @@ func NewPlanFileSource(cfg PlanFileSourceConfig) *PlanFileSource {
 	}
 }
 
-// Produce sends one item per plan entry to the channel. It reads the input
-// line so each item retains the original custom_id. Context cancellation is
-// respected during storage reads and channel sends.
-func (s *PlanFileSource) Produce(ctx context.Context, outgoingRequestCh chan<- pipeline.RequestItem) error {
+// Produce sends one item per plan entry to the channel. It always reads the
+// input line so each item retains the original custom_id: cancel / expire
+// drain still needs that identity in the error file even when inference is
+// skipped. Context cancellation is handled by the dispatcher drain path, not
+// here — dropping entries on cancellation would break batch accounting.
+func (s *PlanFileSource) Produce(_ context.Context, outgoingRequestCh chan<- pipeline.RequestItem) error {
 	defer close(outgoingRequestCh)
 
 	for safeModelID, modelID := range s.modelMap.SafeToModel {
@@ -83,7 +85,7 @@ func (s *PlanFileSource) Produce(ctx context.Context, outgoingRequestCh chan<- p
 		}
 
 		for _, entry := range entries {
-			item, err := s.readEntry(ctx, entry, modelID)
+			item, err := s.readEntry(entry, modelID)
 			if err != nil {
 				return err
 			}
@@ -94,25 +96,24 @@ func (s *PlanFileSource) Produce(ctx context.Context, outgoingRequestCh chan<- p
 	return nil
 }
 
-func (s *PlanFileSource) readEntry(ctx context.Context, entry planEntry, modelID string) (*pipeline.RequestItem, error) {
+func (s *PlanFileSource) readEntry(entry planEntry, modelID string) (*pipeline.RequestItem, error) {
 	var buf []byte
 	if s.storage != nil && s.inputRef != nil {
-		reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		// The input read enumerates requests for drain accounting, so it must
+		// complete even after the dispatch deadline (SLO expiry / cancel /
+		// shutdown): the dispatcher needs every custom_id to record
+		// batch_expired/batch_cancelled. Use a bounded detached context rather
+		// than the abortable dispatch ctx so cancellation can't drop entries.
+		reqCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		rc, err := s.storage.RetrieveRange(reqCtx, s.inputRef.storageName, s.inputRef.folderName, entry.Offset, int64(entry.Length))
 		if err != nil {
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
 			return nil, fmt.Errorf("%w at offset %d: %w", errRequestInputRead, entry.Offset, err)
 		}
 		defer rc.Close()
 
 		buf, err = io.ReadAll(rc)
 		if err != nil {
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
 			return nil, fmt.Errorf("%w at offset %d: %w", errRequestInputRead, entry.Offset, err)
 		}
 	} else if s.inputFile != nil {

--- a/internal/processor/worker/source_planfile_test.go
+++ b/internal/processor/worker/source_planfile_test.go
@@ -882,3 +882,60 @@ func TestPlanFileSource_Produce_StorageRangedReads_Error(t *testing.T) {
 		t.Fatalf("expected errRequestInputRead, got %v", err)
 	}
 }
+
+func TestPlanFileSource_Produce_StorageRangedReads_CancelledContext(t *testing.T) {
+	dir := t.TempDir()
+
+	requests := []batch_types.Request{
+		{CustomID: "c-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]any{"model": "m1", "prompt": "hello"}},
+	}
+
+	var rawInput bytes.Buffer
+	data, _ := json.Marshal(requests[0])
+	data = append(data, '\n')
+	rawInput.Write(data)
+
+	entries := []planEntry{
+		{Offset: 0, Length: uint32(len(data))},
+	}
+	plansDir := filepath.Join(dir, "plans")
+	writePlanFile(t, plansDir, "m1", entries)
+
+	filesClient := mockfiles.NewMockBatchFilesClient(t.TempDir())
+	storageName := "test-input-file.jsonl"
+	folderName := "tenant_tenant-1"
+	if _, err := filesClient.Store(context.Background(), storageName, folderName, 0, 0, bytes.NewReader(rawInput.Bytes())); err != nil {
+		t.Fatalf("Store input: %v", err)
+	}
+
+	inputRef := &inputFileRef{
+		storageName: storageName,
+		folderName:  folderName,
+	}
+
+	client := &mockInferenceClient{}
+	resolver := inference.NewSingleClientResolver(client)
+	defer func() { _ = resolver.Close() }()
+
+	source := NewPlanFileSource(PlanFileSourceConfig{
+		Storage:   filesClient,
+		InputRef:  inputRef,
+		PlansDir:  plansDir,
+		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 1},
+		Resolver:  resolver,
+		Cfg:       config.NewConfig(),
+		Logger:    logr.Discard(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	out := make(chan pipeline.RequestItem, 10)
+	err := source.Produce(ctx, out)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}

--- a/internal/processor/worker/source_planfile_test.go
+++ b/internal/processor/worker/source_planfile_test.go
@@ -808,13 +808,13 @@ func TestPlanFileSource_Produce_StorageRangedReads(t *testing.T) {
 	defer func() { _ = resolver.Close() }()
 
 	source := NewPlanFileSource(PlanFileSourceConfig{
-		Storage:   filesClient,
-		InputRef:  inputRef,
-		PlansDir:  plansDir,
-		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 2},
-		Resolver:  resolver,
-		Cfg:       config.NewConfig(),
-		Logger:    logr.Discard(),
+		Storage:  filesClient,
+		InputRef: inputRef,
+		PlansDir: plansDir,
+		ModelMap: &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 2},
+		Resolver: resolver,
+		Cfg:      config.NewConfig(),
+		Logger:   logr.Discard(),
 	})
 
 	out := make(chan pipeline.RequestItem, 10)
@@ -864,13 +864,13 @@ func TestPlanFileSource_Produce_StorageRangedReads_Error(t *testing.T) {
 	defer func() { _ = resolver.Close() }()
 
 	source := NewPlanFileSource(PlanFileSourceConfig{
-		Storage:   filesClient,
-		InputRef:  inputRef,
-		PlansDir:  plansDir,
-		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 1},
-		Resolver:  resolver,
-		Cfg:       config.NewConfig(),
-		Logger:    logr.Discard(),
+		Storage:  filesClient,
+		InputRef: inputRef,
+		PlansDir: plansDir,
+		ModelMap: &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 1},
+		Resolver: resolver,
+		Cfg:      config.NewConfig(),
+		Logger:   logr.Discard(),
 	})
 
 	out := make(chan pipeline.RequestItem, 10)
@@ -918,13 +918,13 @@ func TestPlanFileSource_Produce_StorageRangedReads_CancelledContext(t *testing.T
 	defer func() { _ = resolver.Close() }()
 
 	source := NewPlanFileSource(PlanFileSourceConfig{
-		Storage:   filesClient,
-		InputRef:  inputRef,
-		PlansDir:  plansDir,
-		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 1},
-		Resolver:  resolver,
-		Cfg:       config.NewConfig(),
-		Logger:    logr.Discard(),
+		Storage:  filesClient,
+		InputRef: inputRef,
+		PlansDir: plansDir,
+		ModelMap: &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 1},
+		Resolver: resolver,
+		Cfg:      config.NewConfig(),
+		Logger:   logr.Discard(),
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/processor/worker/source_planfile_test.go
+++ b/internal/processor/worker/source_planfile_test.go
@@ -1,8 +1,10 @@
 package worker
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +14,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	mockfiles "github.com/llm-d/llm-d-batch-gateway/internal/files_store/mock"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/pipeline"
 	batch_types "github.com/llm-d/llm-d-batch-gateway/internal/shared/types"
@@ -759,5 +762,123 @@ func TestPlanFileSource_Produce_CancellationProducesAllEntries(t *testing.T) {
 		if !seen[want] {
 			t.Errorf("missing custom_id %q after cancelled Produce", want)
 		}
+	}
+}
+
+func TestPlanFileSource_Produce_StorageRangedReads(t *testing.T) {
+	dir := t.TempDir()
+
+	requests := []batch_types.Request{
+		{CustomID: "c-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]any{"model": "m1", "prompt": "hello"}},
+		{CustomID: "c-2", Method: "POST", URL: "/v1/chat/completions", Body: map[string]any{"model": "m1", "prompt": "world"}},
+	}
+
+	var (
+		rawInput bytes.Buffer
+		entries  []planEntry
+	)
+	for _, req := range requests {
+		data, _ := json.Marshal(req)
+		data = append(data, '\n')
+		offset := int64(rawInput.Len())
+		entries = append(entries, planEntry{
+			Offset: offset,
+			Length: uint32(len(data)),
+		})
+		rawInput.Write(data)
+	}
+
+	plansDir := filepath.Join(dir, "plans")
+	writePlanFile(t, plansDir, "m1", entries)
+
+	filesClient := mockfiles.NewMockBatchFilesClient(t.TempDir())
+	storageName := "test-input-file.jsonl"
+	folderName := "tenant_tenant-1"
+	if _, err := filesClient.Store(context.Background(), storageName, folderName, 0, 0, bytes.NewReader(rawInput.Bytes())); err != nil {
+		t.Fatalf("Store input: %v", err)
+	}
+
+	inputRef := &inputFileRef{
+		storageName: storageName,
+		folderName:  folderName,
+	}
+
+	client := &mockInferenceClient{}
+	resolver := inference.NewSingleClientResolver(client)
+	defer func() { _ = resolver.Close() }()
+
+	source := NewPlanFileSource(PlanFileSourceConfig{
+		Storage:   filesClient,
+		InputRef:  inputRef,
+		PlansDir:  plansDir,
+		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 2},
+		Resolver:  resolver,
+		Cfg:       config.NewConfig(),
+		Logger:    logr.Discard(),
+	})
+
+	out := make(chan pipeline.RequestItem, 10)
+	if err := source.Produce(context.Background(), out); err != nil {
+		t.Fatalf("Produce error: %v", err)
+	}
+
+	var items []pipeline.RequestItem
+	for item := range out {
+		items = append(items, item)
+	}
+
+	if len(items) != 2 {
+		t.Fatalf("produced %d items, want 2", len(items))
+	}
+	if items[0].CustomID != "c-1" {
+		t.Errorf("item 0 CustomID = %q, want %q", items[0].CustomID, "c-1")
+	}
+	if items[1].CustomID != "c-2" {
+		t.Errorf("item 1 CustomID = %q, want %q", items[1].CustomID, "c-2")
+	}
+	if items[0].ModelID != "m1" {
+		t.Errorf("item 0 ModelID = %q, want %q", items[0].ModelID, "m1")
+	}
+	if items[0].RequestID == "" {
+		t.Error("expected non-empty RequestID")
+	}
+}
+
+func TestPlanFileSource_Produce_StorageRangedReads_Error(t *testing.T) {
+	dir := t.TempDir()
+
+	entries := []planEntry{
+		{Offset: 0, Length: 50},
+	}
+	plansDir := filepath.Join(dir, "plans")
+	writePlanFile(t, plansDir, "m1", entries)
+
+	filesClient := mockfiles.NewMockBatchFilesClient(t.TempDir())
+	inputRef := &inputFileRef{
+		storageName: "nonexistent.jsonl",
+		folderName:  "tenant_tenant-1",
+	}
+
+	client := &mockInferenceClient{}
+	resolver := inference.NewSingleClientResolver(client)
+	defer func() { _ = resolver.Close() }()
+
+	source := NewPlanFileSource(PlanFileSourceConfig{
+		Storage:   filesClient,
+		InputRef:  inputRef,
+		PlansDir:  plansDir,
+		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 1},
+		Resolver:  resolver,
+		Cfg:       config.NewConfig(),
+		Logger:    logr.Discard(),
+	})
+
+	out := make(chan pipeline.RequestItem, 10)
+	err := source.Produce(context.Background(), out)
+	if err == nil {
+		t.Fatal("expected error from non-existent storage file, got nil")
+	}
+	if !errors.Is(err, errRequestInputRead) {
+		t.Fatalf("expected errRequestInputRead, got %v", err)
 	}
 }

--- a/internal/processor/worker/source_planfile_test.go
+++ b/internal/processor/worker/source_planfile_test.go
@@ -883,7 +883,13 @@ func TestPlanFileSource_Produce_StorageRangedReads_Error(t *testing.T) {
 	}
 }
 
-func TestPlanFileSource_Produce_StorageRangedReads_CancelledContext(t *testing.T) {
+// TestPlanFileSource_Produce_StorageRangedReads_CancelledContextStillProduces
+// verifies that a cancelled context does not stop the storage-backed source
+// from emitting every entry with its original custom_id. The dispatcher drains
+// submitted-but-undispatched requests as batch_expired/batch_cancelled, which
+// requires that identity — it only comes from reading the input line. Aborting
+// the read on cancellation would drop entries and break batch accounting.
+func TestPlanFileSource_Produce_StorageRangedReads_CancelledContextStillProduces(t *testing.T) {
 	dir := t.TempDir()
 
 	requests := []batch_types.Request{
@@ -931,11 +937,18 @@ func TestPlanFileSource_Produce_StorageRangedReads_CancelledContext(t *testing.T
 	cancel()
 
 	out := make(chan pipeline.RequestItem, 10)
-	err := source.Produce(ctx, out)
-	if err == nil {
-		t.Fatal("expected error for cancelled context, got nil")
+	if err := source.Produce(ctx, out); err != nil {
+		t.Fatalf("Produce with cancelled context must still enumerate for the drain path, got: %v", err)
 	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context.Canceled, got %v", err)
+
+	var items []pipeline.RequestItem
+	for item := range out {
+		items = append(items, item)
+	}
+	if len(items) != 1 {
+		t.Fatalf("produced %d items, want 1 (drain needs the custom_id even after cancel)", len(items))
+	}
+	if items[0].CustomID != "c-1" {
+		t.Errorf("item 0 CustomID = %q, want %q", items[0].CustomID, "c-1")
 	}
 }

--- a/internal/processor/worker/test_helpers_test.go
+++ b/internal/processor/worker/test_helpers_test.go
@@ -120,6 +120,9 @@ func (f *failNTimesFilesClient) Retrieve(_ context.Context, _, _ string) (io.Rea
 func (f *failNTimesFilesClient) List(_ context.Context, _ string) ([]filesapi.BatchFileMetadata, error) {
 	return nil, nil
 }
+func (f *failNTimesFilesClient) RetrieveRange(_ context.Context, _, _ string, _ int64, _ int64) (io.ReadCloser, error) {
+	return nil, nil
+}
 func (f *failNTimesFilesClient) Delete(_ context.Context, _, _ string) error { return nil }
 func (f *failNTimesFilesClient) GetContext(p context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithCancel(p)
@@ -145,6 +148,9 @@ func (f *failOnNthCallClient) Retrieve(_ context.Context, _, _ string) (io.ReadC
 	return nil, nil, nil
 }
 func (f *failOnNthCallClient) List(_ context.Context, _ string) ([]filesapi.BatchFileMetadata, error) {
+	return nil, nil
+}
+func (f *failOnNthCallClient) RetrieveRange(_ context.Context, _, _ string, _ int64, _ int64) (io.ReadCloser, error) {
 	return nil, nil
 }
 func (f *failOnNthCallClient) Delete(_ context.Context, _, _ string) error { return nil }
@@ -464,6 +470,8 @@ func setupJobWithOutputFile(t *testing.T, cfg *config.ProcessorConfig, jobID, te
 }
 
 // setupExecutionJob creates a complete job directory with input file, plan files, and model map.
+// It also stores the input data in the mock files client and seeds a FileDB record so that
+// resolveInputFileCoords works for executeJob tests. The returned jobInfo has BatchJob.InputFileID set.
 func setupExecutionJob(
 	t *testing.T,
 	cfg *config.ProcessorConfig,
@@ -477,6 +485,7 @@ func setupExecutionJob(
 
 	jobID := "test-job"
 	tenantID := "tenant-1"
+	inputFileID := "file-test-input"
 
 	jobRootDir, err := env.p.jobRootDir(jobID, tenantID)
 	if err != nil {
@@ -486,8 +495,30 @@ func setupExecutionJob(
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
+	// Write input locally for plan entry computation.
 	inputPath := filepath.Join(jobRootDir, "input.jsonl")
 	rawInput := writeInputJSONL(t, inputPath, requests)
+
+	// Store input data in mock files client for ranged reads.
+	folderName, err := ucom.GetFolderNameByTenantID(tenantID)
+	if err != nil {
+		t.Fatalf("GetFolderNameByTenantID: %v", err)
+	}
+	storageName := ucom.FileStorageName(inputFileID, "input.jsonl")
+	if _, err := env.p.files.storage.Store(
+		context.Background(), storageName, folderName, 0, 0, bytes.NewReader(rawInput),
+	); err != nil {
+		t.Fatalf("Store input in mock files client: %v", err)
+	}
+
+	// Seed FileDB record so resolveInputFileCoords can look it up.
+	fileSpec := &openai.FileObject{Filename: "input.jsonl"}
+	if err := env.p.files.db.DBStore(context.Background(), &db.FileItem{
+		BaseIndexes:  db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
+		BaseContents: db.BaseContents{Spec: mustJSON(t, fileSpec)},
+	}); err != nil {
+		t.Fatalf("DBStore file item: %v", err)
+	}
 
 	allEntries := planEntriesFromLines(rawInput)
 
@@ -516,6 +547,11 @@ func setupExecutionJob(
 	jobInfo := &batch_types.JobInfo{
 		JobID:    jobID,
 		TenantID: tenantID,
+		BatchJob: &openai.Batch{
+			BatchSpec: openai.BatchSpec{
+				InputFileID: inputFileID,
+			},
+		},
 	}
 
 	return env, jobInfo
@@ -678,19 +714,6 @@ func testReadPlanEntries(t *testing.T, planPath string) []planEntry {
 		out = append(out, unmarshalPlanEntry(buf))
 	}
 	return out
-}
-
-func readAtExact(t *testing.T, f *os.File, off int64, n uint32) []byte {
-	t.Helper()
-	buf := make([]byte, n)
-	readN, err := f.ReadAt(buf, off)
-	if err != nil && !errors.Is(err, io.EOF) {
-		t.Fatalf("ReadAt(off=%d,n=%d): %v", off, n, err)
-	}
-	if uint32(readN) != n {
-		t.Fatalf("ReadAt short: got=%d want=%d", readN, n)
-	}
-	return buf
 }
 
 // readNonEmptyJSONLLines reads a JSONL file and returns non-empty lines as byte slices.


### PR DESCRIPTION
## Summary

The preprocessor streams the input file from S3 and writes a full copy to local
disk so the executor can do random-access reads by byte offset. With 20 workers
at the OpenAI max of 200 MB per file, this consumes up to 4 GB of `emptyDir` for
input copies alone, plus the output/error files growing during execution.

This PR adds a `RetrieveRange` method to the `BatchFilesClient` interface that
fetches a byte range from storage (using the S3 `Range` header), and replaces all
local input file reads in the executor with ranged storage reads.

## Changes

### Interface & implementations
- Add `RetrieveRange(ctx, fileName, folderName, offset, length)` to `BatchFilesClient`
- Implement in S3 (Range header), FS (ReadAt), retryclient, tracing, and mock

### Preprocessor
- Remove local `input.jsonl` write — the preprocessor still streams the full file
  for validation and plan building, but no longer writes a local copy
- Plan entry offsets are unchanged — they track byte positions in the stream,
  which match the remote file layout

### Executor
- Add `inputFileRef` struct holding remote storage coordinates (`storageName`, `folderName`)
- Add `resolveInputFileCoords` — resolves an `inputFileID` to storage coordinates via DB lookup (once per job)
- Convert `readRequestLine` from package-level function to `Processor` method that calls `RetrieveRange` internally
- Replace `*os.File` with `*inputFileRef` throughout `executeJob`, `processModel`, `processModelAsync`, `executeOneRequest`, `drainAndFinalize`, `drainUnprocessedRequests`
- `drainUnprocessedRequests` takes a separate `storageCtx` (`mainCtx`) for S3 reads since `progressCtx` (`requestAbortCtx`) may be cancelled during drain

### Removed
- `createLocalInputFile`, `jobInputFilePath`, `inputFileName` constant

## What stays on local disk
- Plan files (small, sequential reads)
- `output.jsonl` and `error.jsonl` (could be streamed to S3 as a follow-up)

## Testing
- All 1051 tests pass
- Regression tests pass
- New `TestRetrieveRange` tests for S3, FS, and retryclient implementations

Fixes https://github.com/llm-d/llm-d-batch-gateway/issues/561