### PR TITLE
fix(postgresql): retry ensureSchema on SQLSTATE 23505

### DIFF
--- a/internal/database/postgresql/db_core.go
+++ b/internal/database/postgresql/db_core.go
@@ -23,12 +23,15 @@ package postgresql
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/llm-d/llm-d-batch-gateway/internal/database/api"
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/logging"
 )
@@ -454,8 +457,23 @@ func (c *pgCore) delete(ctx context.Context, ids []string) (deletedIDs []string,
 	return deletedIDs, nil
 }
 
+// ensureSchema applies the table DDL.
 func (c *pgCore) ensureSchema(ctx context.Context) error {
-	_, err := c.pool.Exec(ctx, c.desc.Schema())
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		if _, err = c.pool.Exec(ctx, c.desc.Schema()); err == nil {
+			return nil
+		}
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != "23505" {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt+1) * 100 * time.Millisecond):
+		}
+	}
 	return err
 }
 

--- a/internal/database/postgresql/db_core.go
+++ b/internal/database/postgresql/db_core.go
@@ -465,6 +465,9 @@ func (c *pgCore) ensureSchema(ctx context.Context) error {
 			return nil
 		}
 		var pgErr *pgconn.PgError
+		// in some environments, especially on fresh boot, different
+		// processes can contend with each other and produce a
+		// duplicate constraint error (23505)
 		if !errors.As(err, &pgErr) || pgErr.Code != "23505" {
 			return err
 		}


### PR DESCRIPTION
Found this working on a batch gateway simulation harness.

When the apiserver, processor, and gc all boot against a fresh database, their concurrent `CREATE TABLE IF NOT EXISTS` calls can race inside postgres and one of them dies with a spurious SQLSTATE 23505 on the `pg_type`/`pg_class` catalog indexes, even though the `IF NOT EXISTS` guard holds. Rare in the wild because real deploys have startup jitter and k8s restarts hide it, but it's a guaranteed crash-loop lottery on any fresh install. The fix is just a bounded retry — the loser tries again and finds the tables in place.

A more durable fix would be to separate all database DDL into a utility that is run via a helm postInstall hook, instead of having 3 separate binaries try to do the same DDL operations — that's #652.
