### PR TITLE
feat(processor): hot-reload model gateway routing from config file

### DIFF
--- a/cmd/batch-processor/main.go
+++ b/cmd/batch-processor/main.go
@@ -59,6 +59,9 @@ func run() error {
 	fs := flag.NewFlagSet("batch-gateway-processor", flag.ExitOnError)
 
 	cfgFilePath := fs.String("config", "cmd/batch-processor/config.yaml", "Path to configuration file")
+	reloadInterval := fs.Duration("model-gateway-reload-interval", 0,
+		"Hot-reload model_gateways / global_inference_gateway from the config file at this interval (0 = disabled). "+
+			"Only sync-dispatch routing is reloaded; other settings require a restart.")
 	klog.InitFlags(fs)
 	_ = fs.Parse(os.Args[1:]) // ExitOnError mode will exit on error
 
@@ -117,7 +120,8 @@ func run() error {
 
 	// init processor
 	logger.V(logging.INFO).Info("Initializing worker processor", "maxWorkers", cfg.NumWorkers)
-	proc, err := worker.NewProcessor(cfg, procClients, hostname, logger)
+	proc, err := worker.NewProcessor(cfg, procClients, hostname, logger,
+		worker.WithModelGatewayConfigReload(*cfgFilePath, *reloadInterval))
 	if err != nil {
 		logger.Error(err, "Failed to create processor")
 		return err

--- a/internal/processor/metrics/metrics.go
+++ b/internal/processor/metrics/metrics.go
@@ -101,6 +101,8 @@ var (
 	aimdConcurrencyLimit          *prometheus.GaugeVec
 	aimdDecreasesTotal            *prometheus.CounterVec
 	aimdIncreasesTotal            *prometheus.CounterVec
+	modelGatewayReloadTotal       *prometheus.CounterVec
+	modelGatewayReloadLastSuccess prometheus.Gauge
 )
 
 // FileType labels for file upload metrics.
@@ -308,6 +310,24 @@ func InitMetrics(cfg config.ProcessorConfig) error {
 		[]string{"endpoint"},
 	)
 
+	// Model gateway config hot-reload outcomes. A sustained non-zero
+	// failure rate means the on-disk config is being edited but the running
+	// routing plane does not reflect it.
+	modelGatewayReloadTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "batch_processor_model_gateway_reload_total",
+			Help: "Total number of model gateway config reload attempts by result (success/failure)",
+		},
+		[]string{"result"},
+	)
+
+	modelGatewayReloadLastSuccess = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "batch_processor_model_gateway_reload_last_success_timestamp_seconds",
+			Help: "Unix timestamp of the last successful model gateway config reload",
+		},
+	)
+
 	// metrics to register
 	metricsToRegister := []prometheus.Collector{
 		jobProcessingDuration,
@@ -329,6 +349,8 @@ func InitMetrics(cfg config.ProcessorConfig) error {
 		aimdConcurrencyLimit,
 		aimdDecreasesTotal,
 		aimdIncreasesTotal,
+		modelGatewayReloadTotal,
+		modelGatewayReloadLastSuccess,
 	}
 
 	for _, metric := range metricsToRegister {
@@ -458,6 +480,18 @@ const (
 	AIMDSignal5xx           = "5xx"
 	AIMDSignalCapacityRetry = "capacity_retry"
 )
+
+// RecordModelGatewayReload increments the model gateway reload counter.
+// result is ResultSuccess or ResultFailed.
+func RecordModelGatewayReload(result string) {
+	modelGatewayReloadTotal.WithLabelValues(result).Inc()
+}
+
+// SetModelGatewayReloadLastSuccess records the timestamp of the last
+// successful model gateway config reload.
+func SetModelGatewayReloadLastSuccess(t time.Time) {
+	modelGatewayReloadLastSuccess.Set(float64(t.Unix()))
+}
 
 // E2E latency status labels. Must match the terminal states used in
 // job_runner.go, worker.go, and recovery.go.

--- a/internal/processor/metrics/metrics.go
+++ b/internal/processor/metrics/metrics.go
@@ -355,7 +355,25 @@ func InitMetrics(cfg config.ProcessorConfig) error {
 
 	for _, metric := range metricsToRegister {
 		if err := prometheus.Register(metric); err != nil {
-			if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			if already, ok := err.(prometheus.AlreadyRegisteredError); ok {
+				// A repeated InitMetrics (tests, in-process restart)
+				// re-created every collector, leaving the package vars
+				// pointing at fresh, unregistered instances. Adopt the
+				// already-registered collector for the reload metrics so
+				// RecordModelGatewayReload / SetModelGatewayReloadLastSuccess
+				// keep writing to what the Prometheus endpoint serves.
+				// (The older metrics keep their pre-existing
+				// first-registration-wins behavior.)
+				switch metric {
+				case modelGatewayReloadTotal:
+					if existing, ok := already.ExistingCollector.(*prometheus.CounterVec); ok {
+						modelGatewayReloadTotal = existing
+					}
+				case modelGatewayReloadLastSuccess:
+					if existing, ok := already.ExistingCollector.(prometheus.Gauge); ok {
+						modelGatewayReloadLastSuccess = existing
+					}
+				}
 				continue
 			}
 			return err

--- a/internal/processor/metrics/metrics_test.go
+++ b/internal/processor/metrics/metrics_test.go
@@ -386,3 +386,30 @@ func TestInitMetrics_Twice_DoesNotError(t *testing.T) {
 		}
 	})
 }
+
+// TestInitMetrics_Twice_ReloadMetricsStayRegistered: a repeated InitMetrics
+// re-creates every collector; the reload metric package vars must adopt the
+// already-registered instances, otherwise Record/Set write into orphaned
+// collectors and the Prometheus endpoint keeps serving the stale, empty one.
+func TestInitMetrics_Twice_ReloadMetricsStayRegistered(t *testing.T) {
+	withIsolatedPromRegistry(t, func(reg *prometheus.Registry) {
+		cfg := *config.NewConfig()
+		if err := InitMetrics(cfg); err != nil {
+			t.Fatalf("first InitMetrics: %v", err)
+		}
+		if err := InitMetrics(cfg); err != nil {
+			t.Fatalf("second InitMetrics: %v", err)
+		}
+
+		RecordModelGatewayReload(ResultSuccess)
+		SetModelGatewayReloadLastSuccess(time.Unix(1234, 0))
+
+		f := collectFamilies(t, reg)
+		if v := counterWithLabels(f["batch_processor_model_gateway_reload_total"], map[string]string{"result": ResultSuccess}); v != 1 {
+			t.Fatalf("reload counter{success}=%v, want 1 (updates must hit the registered collector)", v)
+		}
+		if v := gaugeValue(f["batch_processor_model_gateway_reload_last_success_timestamp_seconds"]); v != 1234 {
+			t.Fatalf("reload last-success gauge=%v, want 1234 (updates must hit the registered collector)", v)
+		}
+	})
+}

--- a/internal/processor/worker/config_reload.go
+++ b/internal/processor/worker/config_reload.go
@@ -307,7 +307,14 @@ func (p *Processor) applyModelGatewayConfig(newCfg *config.ProcessorConfig, logg
 	oldSnapshot := p.routing.Load()
 	globalObjective, modelObjectives := objectivesFromConfig(newCfg)
 	if oldSnapshot != nil {
-		sameFiles := oldSnapshot.referencedFilesHash == nil || *oldSnapshot.referencedFilesHash == newFilesHash
+		// A nil stored digest means the baseline hash could not be computed
+		// (e.g. a referenced file was unreadable at startup). It is
+		// "unknown", not "same content": an otherwise-identical reload
+		// skipped here would never anchor the digest, and every later
+		// content rotation would be misjudged as unchanged forever. Unknown
+		// forces one rebuild, after which the new snapshot carries the
+		// computed digest and change detection is re-anchored.
+		sameFiles := oldSnapshot.referencedFilesHash != nil && *oldSnapshot.referencedFilesHash == newFilesHash
 		if resolvedGatewaysEqual(oldSnapshot.gateways, resolved) &&
 			oldSnapshot.globalObjective == globalObjective &&
 			maps.Equal(oldSnapshot.modelObjectives, modelObjectives) &&

--- a/internal/processor/worker/config_reload.go
+++ b/internal/processor/worker/config_reload.go
@@ -214,8 +214,8 @@ func referencedFilesHash(cfg *config.ProcessorConfig) ([sha256.Size]byte, error)
 
 // referencedGatewayFiles lists the external files whose contents feed into
 // gateway client construction: explicit api_key_file paths, the mounted
-// secret behind api_key_name (and the global gateway's fallback
-// inference-api-key when neither key field is set), and TLS cert/key files.
+// secret behind api_key_name, the global gateway's fallback
+// inference-api-key, and TLS cert/key files.
 func referencedGatewayFiles(cfg *config.ProcessorConfig) []string {
 	var files []string
 	add := func(gw *config.ModelGatewayConfig) {
@@ -235,10 +235,17 @@ func referencedGatewayFiles(cfg *config.ProcessorConfig) []string {
 		}
 	}
 	add(cfg.GlobalInferenceGateway)
-	if g := cfg.GlobalInferenceGateway; g != nil && g.APIKeyFile == "" && g.APIKeyName == "" {
+	if cfg.GlobalInferenceGateway != nil {
 		// ResolveModelGateways falls back to the mounted inference-api-key
-		// for the global gateway; its rotation must reload routing too.
-		files = append(files, ucom.SecretFilePath(ucom.SecretKeyInferenceAPI))
+		// for the global gateway whenever the explicitly configured key
+		// resolves to an empty string (including an api_key_file or
+		// api_key_name whose content is empty). The config layer only sees
+		// paths, not key contents, so it cannot tell whether the fallback
+		// will actually be used — fingerprint the fallback secret
+		// unconditionally. With a non-empty explicit key the fallback is
+		// unused; hashing one extra file is acceptable conservative
+		// behavior. Per-model gateways have no such fallback.
+		files = append(files, fallbackSecretPath)
 	}
 	for _, model := range slices.Sorted(maps.Keys(cfg.ModelGateways)) {
 		gw := cfg.ModelGateways[model]
@@ -247,6 +254,11 @@ func referencedGatewayFiles(cfg *config.ProcessorConfig) []string {
 	slices.Sort(files)
 	return slices.Compact(files)
 }
+
+// fallbackSecretPath is the mounted inference-api-key path that
+// ResolveModelGateways falls back to for the global gateway. Declared as a
+// var so tests can point it at a temp file.
+var fallbackSecretPath = ucom.SecretFilePath(ucom.SecretKeyInferenceAPI)
 
 // newSyncResolver builds the sync routing resolver for a freshly resolved
 // gateway set — the same construction as startup. Declared as a var so

--- a/internal/processor/worker/config_reload.go
+++ b/internal/processor/worker/config_reload.go
@@ -17,9 +17,11 @@ limitations under the License.
 // Hot reload of the model_gateways / global_inference_gateway section of
 // the processor config file.
 //
-// A ticker polls the config file and compares SHA-256 content hashes. On a
-// change, the file is re-parsed and re-validated through the exact same
-// code path as startup (LoadFromYAML + Validate + ResolveModelGateways).
+// A ticker polls the config file and compares SHA-256 fingerprints covering
+// the config content plus every referenced external file (API key and TLS
+// material), so Secret rotations alone trigger a reload. On a change, the
+// file is re-parsed and re-validated through the exact same code path as
+// startup (LoadFromYAML + Validate + ResolveModelGateways).
 // A new immutable routingSnapshot (resolver + endpoint limits + objectives)
 // is built and atomically swapped in; ANY error keeps the old routing and
 // records a failure metric. Only the sync-dispatch routing plane is
@@ -39,11 +41,13 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/metrics"
+	ucom "github.com/llm-d/llm-d-batch-gateway/internal/util/com"
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/logging"
 	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
 )
@@ -55,6 +59,10 @@ const defaultModelGatewayCloseGracePeriod = 30 * time.Second
 
 // startModelGatewayWatcher starts the config-file watcher when reload is
 // enabled. No-op for a zero interval or async dispatch mode.
+// The given ctx should be the polling loop's context: when the processor
+// stops accepting work (guard shutdown / SIGTERM), the routing plane must
+// stop mutating. The goroutine is tracked by p.watcherWG so Run can wait
+// for it to exit before returning.
 func (p *Processor) startModelGatewayWatcher(ctx context.Context) {
 	logger := logr.FromContextOrDiscard(ctx)
 	if p.gwReloadPath == "" || p.gwReloadInterval <= 0 {
@@ -69,19 +77,34 @@ func (p *Processor) startModelGatewayWatcher(ctx context.Context) {
 		"interval", p.gwReloadInterval,
 		"closeGracePeriod", defaultModelGatewayCloseGracePeriod,
 	)
-	go p.modelGatewayWatchLoop(ctx)
+	p.watcherWG.Add(1)
+	go func() {
+		defer p.watcherWG.Done()
+		p.modelGatewayWatchLoop(ctx)
+	}()
 }
 
 // modelGatewayWatchLoop polls the config file and applies changes.
+//
+// Change detection fingerprints the main config file PLUS the contents of
+// every external file the gateway section references (api_key_file, the
+// file behind api_key_name, and TLS cert/key files): a Secret rotation that
+// only rewrites the key file must still reload routing.
+//
+// Retry semantics: the remembered fingerprint is updated only after a
+// successful reload. Any failure (unreadable file, invalid config, resolver
+// error, rejected change) leaves the fingerprint untouched, so the next
+// poll retries the same failing content instead of silently sticking with
+// the last good routing until the config text happens to change again.
 func (p *Processor) modelGatewayWatchLoop(ctx context.Context) {
 	logger := logr.FromContextOrDiscard(ctx)
 	ticker := time.NewTicker(p.gwReloadInterval)
 	defer ticker.Stop()
 
-	var lastHash [sha256.Size]byte
-	hashValid := false
-	if data, err := os.ReadFile(p.gwReloadPath); err == nil {
-		lastHash, hashValid = sha256.Sum256(data), true
+	var lastFP [sha256.Size]byte
+	fpValid := false
+	if fp, _, ok := p.reloadFingerprint(logger); ok {
+		lastFP, fpValid = fp, ok
 	}
 
 	for {
@@ -89,35 +112,132 @@ func (p *Processor) modelGatewayWatchLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			data, err := os.ReadFile(p.gwReloadPath)
-			if err != nil {
-				logger.Error(err, "Model gateway config reload failed: cannot read config file", "path", p.gwReloadPath)
-				metrics.RecordModelGatewayReload(metrics.ResultFailed)
-				hashValid = false // force a full retry once the file is readable again
+			fp, newCfg, ok := p.reloadFingerprint(logger)
+			if !ok {
+				// File unreadable or a referenced file vanished between
+				// validation and fingerprinting — transient; keep retrying.
+				fpValid = false
 				continue
 			}
-			hash := sha256.Sum256(data)
-			if hashValid && hash == lastHash {
+			if fpValid && fp == lastFP {
 				continue
 			}
-			lastHash, hashValid = hash, true
-			logger.V(logging.INFO).Info("Config file change detected, reloading model gateways", "path", p.gwReloadPath)
+			logger.V(logging.INFO).Info("Config change detected, reloading model gateways", "path", p.gwReloadPath)
 
-			newCfg, err := loadProcessorConfig(p.gwReloadPath)
-			if err != nil {
-				logger.Error(err, "Model gateway config reload failed: invalid config", "path", p.gwReloadPath)
-				metrics.RecordModelGatewayReload(metrics.ResultFailed)
-				continue
-			}
 			if err := p.applyModelGatewayConfig(newCfg, logger); err != nil {
 				logger.Error(err, "Model gateway config reload failed; keeping current routing", "path", p.gwReloadPath)
 				metrics.RecordModelGatewayReload(metrics.ResultFailed)
-				continue
+				continue // retry the same content on the next tick
 			}
+			lastFP, fpValid = fp, true
 			metrics.RecordModelGatewayReload(metrics.ResultSuccess)
 			metrics.SetModelGatewayReloadLastSuccess(time.Now())
 		}
 	}
+}
+
+// reloadFingerprint reads the config file, parses and validates it, and
+// returns the parsed config together with a combined content hash of the
+// config and every referenced external file. ok=false means reloading
+// cannot be attempted right now (unreadable or invalid input); the failure
+// metric is recorded here.
+func (p *Processor) reloadFingerprint(logger logr.Logger) ([sha256.Size]byte, *config.ProcessorConfig, bool) {
+	var fp [sha256.Size]byte
+	data, err := os.ReadFile(p.gwReloadPath)
+	if err != nil {
+		logger.Error(err, "Model gateway config reload failed: cannot read config file", "path", p.gwReloadPath)
+		metrics.RecordModelGatewayReload(metrics.ResultFailed)
+		return fp, nil, false
+	}
+	newCfg, err := loadProcessorConfig(p.gwReloadPath)
+	if err != nil {
+		logger.Error(err, "Model gateway config reload failed: invalid config", "path", p.gwReloadPath)
+		metrics.RecordModelGatewayReload(metrics.ResultFailed)
+		return fp, nil, false
+	}
+	fp, err = gatewayFingerprint(data, newCfg)
+	if err != nil {
+		logger.Error(err, "Model gateway config reload failed: cannot read referenced files", "path", p.gwReloadPath)
+		metrics.RecordModelGatewayReload(metrics.ResultFailed)
+		return fp, nil, false
+	}
+	return fp, newCfg, true
+}
+
+// gatewayFingerprint hashes the config file content together with the
+// contents of every external file the gateway section references, so key or
+// certificate rotations alone trigger a reload. Referenced files are
+// re-read from disk here (they are read again during resolve; worst case a
+// rotation racing this read just causes one extra reload next poll).
+// A referenced file that does not exist hashes as absent rather than
+// failing — resolveGatewayAPIKey treats a missing named secret the same way.
+func gatewayFingerprint(configData []byte, cfg *config.ProcessorConfig) ([sha256.Size]byte, error) {
+	var zero [sha256.Size]byte
+	h := sha256.New()
+	h.Write(configData)
+	for _, f := range referencedGatewayFiles(cfg) {
+		h.Write([]byte{0})
+		h.Write([]byte(f))
+		h.Write([]byte{0})
+		data, err := os.ReadFile(f)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return zero, fmt.Errorf("read referenced file %q: %w", f, err)
+		}
+		h.Write(data)
+	}
+	var fp [sha256.Size]byte
+	copy(fp[:], h.Sum(nil))
+	return fp, nil
+}
+
+// referencedGatewayFiles lists the external files whose contents feed into
+// gateway client construction: explicit api_key_file paths, the mounted
+// secret behind api_key_name (and the global gateway's fallback
+// inference-api-key when neither key field is set), and TLS cert/key files.
+func referencedGatewayFiles(cfg *config.ProcessorConfig) []string {
+	var files []string
+	add := func(gw *config.ModelGatewayConfig) {
+		if gw == nil {
+			return
+		}
+		if gw.APIKeyFile != "" {
+			files = append(files, gw.APIKeyFile)
+		}
+		if gw.APIKeyName != "" {
+			files = append(files, ucom.SecretFilePath(gw.APIKeyName))
+		}
+		for _, f := range []string{gw.TLSCACertFile, gw.TLSClientCertFile, gw.TLSClientKeyFile} {
+			if f != "" {
+				files = append(files, f)
+			}
+		}
+	}
+	add(cfg.GlobalInferenceGateway)
+	if g := cfg.GlobalInferenceGateway; g != nil && g.APIKeyFile == "" && g.APIKeyName == "" {
+		// ResolveModelGateways falls back to the mounted inference-api-key
+		// for the global gateway; its rotation must reload routing too.
+		files = append(files, ucom.SecretFilePath(ucom.SecretKeyInferenceAPI))
+	}
+	for _, model := range slices.Sorted(maps.Keys(cfg.ModelGateways)) {
+		gw := cfg.ModelGateways[model]
+		add(&gw)
+	}
+	slices.Sort(files)
+	return slices.Compact(files)
+}
+
+// newSyncResolver builds the sync routing resolver for a freshly resolved
+// gateway set — the same construction as startup. Declared as a var so
+// tests can substitute a resolver over closeable fake clients when asserting
+// failure-path resource cleanup.
+var newSyncResolver = func(resolved *config.ResolvedGateways, logger logr.Logger) (*inference.GatewayResolver, error) {
+	if resolved.Global != nil {
+		return inference.NewGlobalResolver(*resolved.Global, logger)
+	}
+	return inference.NewPerModelResolver(resolved.PerModel, logger)
 }
 
 // loadProcessorConfig parses and validates the config file through the same
@@ -135,7 +255,17 @@ func loadProcessorConfig(path string) (*config.ProcessorConfig, error) {
 
 // applyModelGatewayConfig builds a new routing snapshot from the reloaded
 // config and swaps it in. Any error leaves the current routing untouched.
-func (p *Processor) applyModelGatewayConfig(newCfg *config.ProcessorConfig, logger logr.Logger) error {
+//
+// route_key_method is explicitly NOT reloadable: the resolver is keyed on
+// it and request construction (preprocessor, plan source, dispatcher) uses
+// it too. Reloading it would silently split the two sides of the lookup, so
+// a change is rejected and surfaced as a reload failure — restart required.
+func (p *Processor) applyModelGatewayConfig(newCfg *config.ProcessorConfig, logger logr.Logger) (retErr error) {
+	if newCfg.RouteKeyMethod != p.cfg.RouteKeyMethod {
+		return fmt.Errorf("route_key_method changed from %q to %q: not hot-reloadable, restart the processor to apply",
+			p.cfg.RouteKeyMethod, newCfg.RouteKeyMethod)
+	}
+
 	resolved, err := config.ResolveModelGateways(newCfg)
 	if err != nil {
 		return fmt.Errorf("resolve model gateways: %w", err)
@@ -155,16 +285,16 @@ func (p *Processor) applyModelGatewayConfig(newCfg *config.ProcessorConfig, logg
 		}
 	}
 
-	var resolver *inference.GatewayResolver
-	switch {
-	case resolved.Global != nil:
-		resolver, err = inference.NewGlobalResolver(*resolved.Global, logger)
-	default:
-		resolver, err = inference.NewPerModelResolver(resolved.PerModel, logger)
-	}
+	resolver, err := newSyncResolver(resolved, logger)
 	if err != nil {
 		return fmt.Errorf("create inference clients: %w", err)
 	}
+	// A resolver that never gets swapped in must not leak its transports.
+	defer func() {
+		if retErr != nil {
+			_ = resolver.Close()
+		}
+	}()
 
 	var prevLimits map[inference.InferenceClient]*endpointLimit
 	if oldSnapshot != nil {

--- a/internal/processor/worker/config_reload.go
+++ b/internal/processor/worker/config_reload.go
@@ -166,15 +166,34 @@ func (p *Processor) reloadFingerprint(logger logr.Logger) ([sha256.Size]byte, *c
 
 // gatewayFingerprint hashes the config file content together with the
 // contents of every external file the gateway section references, so key or
-// certificate rotations alone trigger a reload. Referenced files are
-// re-read from disk here (they are read again during resolve; worst case a
-// rotation racing this read just causes one extra reload next poll).
-// A referenced file that does not exist hashes as absent rather than
-// failing — resolveGatewayAPIKey treats a missing named secret the same way.
+// certificate rotations alone trigger a reload.
 func gatewayFingerprint(configData []byte, cfg *config.ProcessorConfig) ([sha256.Size]byte, error) {
 	var zero [sha256.Size]byte
+	filesHash, err := referencedFilesHash(cfg)
+	if err != nil {
+		return zero, err
+	}
 	h := sha256.New()
 	h.Write(configData)
+	h.Write(filesHash[:])
+	var fp [sha256.Size]byte
+	copy(fp[:], h.Sum(nil))
+	return fp, nil
+}
+
+// referencedFilesHash hashes the path set and contents of every external
+// file the gateway section references. It backs both the change-detection
+// fingerprint and the no-op decision in applyModelGatewayConfig, so a
+// rotation that triggers a reload necessarily also forces a resolver
+// rebuild (there is exactly one definition of "referenced content
+// changed"). Referenced files are re-read from disk here (they are read
+// again during resolve / client construction; worst case a rotation racing
+// this read just causes one extra reload next poll). A referenced file that
+// does not exist hashes as absent rather than failing — resolveGatewayAPIKey
+// treats a missing named secret the same way.
+func referencedFilesHash(cfg *config.ProcessorConfig) ([sha256.Size]byte, error) {
+	var zero [sha256.Size]byte
+	h := sha256.New()
 	for _, f := range referencedGatewayFiles(cfg) {
 		h.Write([]byte{0})
 		h.Write([]byte(f))
@@ -274,12 +293,25 @@ func (p *Processor) applyModelGatewayConfig(newCfg *config.ProcessorConfig, logg
 		return fmt.Errorf("switching to dispatch_mode %q at runtime is not supported", config.DispatchModeAsync)
 	}
 
+	// The resolved gateway set alone cannot see referenced-file content
+	// changes (GatewayClientConfig holds TLS paths, not contents), so the
+	// no-op check below also compares the content digest stored with the
+	// current snapshot. A changed digest (TLS/key rotation in place, or a
+	// newly introduced referenced file) forces a resolver rebuild even when
+	// the resolved gateway set is byte-identical.
+	newFilesHash, err := referencedFilesHash(newCfg)
+	if err != nil {
+		return fmt.Errorf("read referenced gateway files: %w", err)
+	}
+
 	oldSnapshot := p.routing.Load()
 	globalObjective, modelObjectives := objectivesFromConfig(newCfg)
 	if oldSnapshot != nil {
+		sameFiles := oldSnapshot.referencedFilesHash == nil || *oldSnapshot.referencedFilesHash == newFilesHash
 		if resolvedGatewaysEqual(oldSnapshot.gateways, resolved) &&
 			oldSnapshot.globalObjective == globalObjective &&
-			maps.Equal(oldSnapshot.modelObjectives, modelObjectives) {
+			maps.Equal(oldSnapshot.modelObjectives, modelObjectives) &&
+			sameFiles {
 			logger.V(logging.INFO).Info("Gateway routing unchanged after reload; keeping current routing")
 			return nil
 		}
@@ -315,11 +347,12 @@ func (p *Processor) applyModelGatewayConfig(newCfg *config.ProcessorConfig, logg
 	)
 
 	p.swapRouting(&routingSnapshot{
-		resolver:        resolver,
-		endpointLimits:  limits,
-		globalObjective: globalObjective,
-		modelObjectives: modelObjectives,
-		gateways:        resolved,
+		resolver:            resolver,
+		endpointLimits:      limits,
+		globalObjective:     globalObjective,
+		modelObjectives:     modelObjectives,
+		gateways:            resolved,
+		referencedFilesHash: &newFilesHash,
 	}, defaultModelGatewayCloseGracePeriod, logger)
 	return nil
 }

--- a/internal/processor/worker/config_reload.go
+++ b/internal/processor/worker/config_reload.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Hot reload of the model_gateways / global_inference_gateway section of
+// the processor config file.
+//
+// A ticker polls the config file and compares SHA-256 content hashes. On a
+// change, the file is re-parsed and re-validated through the exact same
+// code path as startup (LoadFromYAML + Validate + ResolveModelGateways).
+// A new immutable routingSnapshot (resolver + endpoint limits + objectives)
+// is built and atomically swapped in; ANY error keeps the old routing and
+// records a failure metric. Only the sync-dispatch routing plane is
+// replaced — DB/queue/file clients, the polling loop and in-flight jobs
+// are untouched.
+//
+// Removed models need no dedicated teardown: queued jobs for an
+// unconfigured model already fail with model_not_found written to the job
+// error file via the existing preprocessor / dispatcher paths (their
+// ClientFor lookup simply starts returning nil after the swap).
+
+package worker
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"maps"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/metrics"
+	"github.com/llm-d/llm-d-batch-gateway/internal/util/logging"
+	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
+)
+
+// defaultModelGatewayCloseGracePeriod is how long replaced gateway clients
+// outlive a routing swap before their idle connections are closed, giving
+// in-flight jobs time to finish against the old endpoints.
+const defaultModelGatewayCloseGracePeriod = 30 * time.Second
+
+// startModelGatewayWatcher starts the config-file watcher when reload is
+// enabled. No-op for a zero interval or async dispatch mode.
+func (p *Processor) startModelGatewayWatcher(ctx context.Context) {
+	logger := logr.FromContextOrDiscard(ctx)
+	if p.gwReloadPath == "" || p.gwReloadInterval <= 0 {
+		return
+	}
+	if p.asyncInference != nil {
+		logger.V(logging.INFO).Info("Model gateway config reload is not supported for async dispatch mode; watcher not started")
+		return
+	}
+	logger.V(logging.INFO).Info("Starting model gateway config watcher",
+		"path", p.gwReloadPath,
+		"interval", p.gwReloadInterval,
+		"closeGracePeriod", defaultModelGatewayCloseGracePeriod,
+	)
+	go p.modelGatewayWatchLoop(ctx)
+}
+
+// modelGatewayWatchLoop polls the config file and applies changes.
+func (p *Processor) modelGatewayWatchLoop(ctx context.Context) {
+	logger := logr.FromContextOrDiscard(ctx)
+	ticker := time.NewTicker(p.gwReloadInterval)
+	defer ticker.Stop()
+
+	var lastHash [sha256.Size]byte
+	hashValid := false
+	if data, err := os.ReadFile(p.gwReloadPath); err == nil {
+		lastHash, hashValid = sha256.Sum256(data), true
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			data, err := os.ReadFile(p.gwReloadPath)
+			if err != nil {
+				logger.Error(err, "Model gateway config reload failed: cannot read config file", "path", p.gwReloadPath)
+				metrics.RecordModelGatewayReload(metrics.ResultFailed)
+				hashValid = false // force a full retry once the file is readable again
+				continue
+			}
+			hash := sha256.Sum256(data)
+			if hashValid && hash == lastHash {
+				continue
+			}
+			lastHash, hashValid = hash, true
+			logger.V(logging.INFO).Info("Config file change detected, reloading model gateways", "path", p.gwReloadPath)
+
+			newCfg, err := loadProcessorConfig(p.gwReloadPath)
+			if err != nil {
+				logger.Error(err, "Model gateway config reload failed: invalid config", "path", p.gwReloadPath)
+				metrics.RecordModelGatewayReload(metrics.ResultFailed)
+				continue
+			}
+			if err := p.applyModelGatewayConfig(newCfg, logger); err != nil {
+				logger.Error(err, "Model gateway config reload failed; keeping current routing", "path", p.gwReloadPath)
+				metrics.RecordModelGatewayReload(metrics.ResultFailed)
+				continue
+			}
+			metrics.RecordModelGatewayReload(metrics.ResultSuccess)
+			metrics.SetModelGatewayReloadLastSuccess(time.Now())
+		}
+	}
+}
+
+// loadProcessorConfig parses and validates the config file through the same
+// path as startup (defaults + LoadFromYAML + Validate).
+func loadProcessorConfig(path string) (*config.ProcessorConfig, error) {
+	cfg := config.NewConfig()
+	if err := cfg.LoadFromYAML(path); err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// applyModelGatewayConfig builds a new routing snapshot from the reloaded
+// config and swaps it in. Any error leaves the current routing untouched.
+func (p *Processor) applyModelGatewayConfig(newCfg *config.ProcessorConfig, logger logr.Logger) error {
+	resolved, err := config.ResolveModelGateways(newCfg)
+	if err != nil {
+		return fmt.Errorf("resolve model gateways: %w", err)
+	}
+	if resolved.Async != nil {
+		return fmt.Errorf("switching to dispatch_mode %q at runtime is not supported", config.DispatchModeAsync)
+	}
+
+	oldSnapshot := p.routing.Load()
+	globalObjective, modelObjectives := objectivesFromConfig(newCfg)
+	if oldSnapshot != nil {
+		if resolvedGatewaysEqual(oldSnapshot.gateways, resolved) &&
+			oldSnapshot.globalObjective == globalObjective &&
+			maps.Equal(oldSnapshot.modelObjectives, modelObjectives) {
+			logger.V(logging.INFO).Info("Gateway routing unchanged after reload; keeping current routing")
+			return nil
+		}
+	}
+
+	var resolver *inference.GatewayResolver
+	switch {
+	case resolved.Global != nil:
+		resolver, err = inference.NewGlobalResolver(*resolved.Global, logger)
+	default:
+		resolver, err = inference.NewPerModelResolver(resolved.PerModel, logger)
+	}
+	if err != nil {
+		return fmt.Errorf("create inference clients: %w", err)
+	}
+
+	var prevLimits map[inference.InferenceClient]*endpointLimit
+	if oldSnapshot != nil {
+		prevLimits = oldSnapshot.endpointLimits
+	}
+	limits, err := p.buildEndpointLimits(resolver, prevLimits, logger)
+	if err != nil {
+		return fmt.Errorf("build endpoint limits: %w", err)
+	}
+
+	added, removed, updated := routingDiff(nilOrGateways(oldSnapshot), resolved)
+	logger.V(logging.INFO).Info("Model gateway routing reloaded",
+		"numModelGateways", len(resolved.PerModel),
+		"globalGateway", resolved.Global != nil,
+		"addedModels", added,
+		"removedModels", removed,
+		"updatedModels", updated,
+	)
+
+	p.swapRouting(&routingSnapshot{
+		resolver:        resolver,
+		endpointLimits:  limits,
+		globalObjective: globalObjective,
+		modelObjectives: modelObjectives,
+		gateways:        resolved,
+	}, defaultModelGatewayCloseGracePeriod, logger)
+	return nil
+}
+
+func nilOrGateways(s *routingSnapshot) *config.ResolvedGateways {
+	if s == nil {
+		return nil
+	}
+	return s.gateways
+}

--- a/internal/processor/worker/config_reload_test.go
+++ b/internal/processor/worker/config_reload_test.go
@@ -646,6 +646,61 @@ func TestApplyModelGatewayConfigTLSRotation(t *testing.T) {
 	}
 }
 
+// TestApplyModelGatewayConfigNilBaselineHashForcesRebuild: when the startup
+// baseline could not hash the referenced files (a file was unreadable at
+// startup), the snapshot stores a nil digest — "unknown", not "unchanged".
+// An otherwise-identical reload must then rebuild the resolver once to
+// anchor the digest; treating nil as "same content" would skip the swap
+// without anchoring and permanently hide subsequent TLS/key rotations.
+func TestApplyModelGatewayConfigNilBaselineHashForcesRebuild(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	writeTestCACert(t, caPath, 1, "ca-one")
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeGatewayConfigWithTLS(t, cfgPath, caPath, "")
+	p := newReloadTestProcessor(t, cfgPath, 0)
+
+	// Simulate a startup baseline whose referenced files were unreadable.
+	baseline := p.routing.Load()
+	baseline.referencedFilesHash = nil
+
+	apply := func(t *testing.T) {
+		t.Helper()
+		newCfg, err := loadProcessorConfig(cfgPath)
+		if err != nil {
+			t.Fatalf("loadProcessorConfig: %v", err)
+		}
+		if err := p.applyModelGatewayConfig(newCfg, testLogger(t)); err != nil {
+			t.Fatalf("applyModelGatewayConfig: %v", err)
+		}
+	}
+
+	// Same gateways, same referenced content, unknown baseline digest:
+	// rebuild once and anchor the digest instead of no-op'ing forever.
+	apply(t)
+	anchored := p.routing.Load()
+	if anchored == baseline {
+		t.Fatal("nil baseline digest must force a rebuild, not a permanent no-op")
+	}
+	if anchored.referencedFilesHash == nil {
+		t.Fatal("the rebuilt snapshot must anchor the referenced files digest")
+	}
+
+	// Anchored now: an unchanged reload is a true no-op again.
+	apply(t)
+	if got := p.routing.Load(); got != anchored {
+		t.Fatal("unchanged config after anchoring must not replace the routing snapshot")
+	}
+
+	// And a later content-only rotation must still rebuild the resolver.
+	writeTestCACert(t, caPath, 2, "ca-two")
+	apply(t)
+	rotated := p.routing.Load()
+	if rotated == anchored || rotated.resolver == anchored.resolver {
+		t.Fatal("TLS cert rotation after anchoring must rebuild the resolver")
+	}
+}
+
 // TestApplyModelGatewayConfigAddsReferencedFile: introducing a new
 // referenced file can leave the resolved gateway set byte-identical (here:
 // an api key file whose trimmed content is the empty key that was used

--- a/internal/processor/worker/config_reload_test.go
+++ b/internal/processor/worker/config_reload_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package worker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
+)
+
+// writeGatewayConfig writes a valid processor config whose sync gateway
+// section contains exactly the given model -> URL mappings.
+func writeGatewayConfig(t *testing.T, path string, models map[string]string) {
+	t.Helper()
+	content := ""
+	for model, url := range models {
+		content += fmt.Sprintf(`  %s:
+    url: %q
+    request_timeout: 30s
+    max_retries: 1
+    initial_backoff: 1s
+    max_backoff: 5s
+`, model, url)
+	}
+	if err := os.WriteFile(path, []byte("model_gateways:\n"+content), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+}
+
+// newReloadTestProcessor builds a Processor seeded with the same config the
+// temp file holds, as if it had just started up from that file: the routing
+// snapshot is published the way initConcurrencyControls does in Run().
+func newReloadTestProcessor(t *testing.T, cfgPath string, interval time.Duration) *Processor {
+	t.Helper()
+
+	cfg, err := loadProcessorConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("loadProcessorConfig: %v", err)
+	}
+	p, err := NewProcessor(cfg, validProcessorClients(t), "test-processor", testLogger(t),
+		WithModelGatewayConfigReload(cfgPath, interval))
+	if err != nil {
+		t.Fatalf("NewProcessor: %v", err)
+	}
+	p.makeGuard = func(string) func() { return func() {} }
+
+	resolved, err := config.ResolveModelGateways(cfg)
+	if err != nil {
+		t.Fatalf("ResolveModelGateways: %v", err)
+	}
+	resolver, err := inference.NewPerModelResolver(resolved.PerModel, testLogger(t))
+	if err != nil {
+		t.Fatalf("NewPerModelResolver: %v", err)
+	}
+	limits, err := p.buildEndpointLimits(resolver, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("buildEndpointLimits: %v", err)
+	}
+	globalObjective, modelObjectives := objectivesFromConfig(cfg)
+	p.routing.Store(&routingSnapshot{
+		resolver:        resolver,
+		endpointLimits:  limits,
+		globalObjective: globalObjective,
+		modelObjectives: modelObjectives,
+		gateways:        resolved,
+	})
+	return p
+}
+
+func TestApplyModelGatewayConfig(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeGatewayConfig(t, cfgPath, map[string]string{"m1": "http://a:8000"})
+	p := newReloadTestProcessor(t, cfgPath, 0)
+
+	apply := func(t *testing.T, models map[string]string) error {
+		newPath := filepath.Join(t.TempDir(), "config.yaml")
+		writeGatewayConfig(t, newPath, models)
+		newCfg, err := loadProcessorConfig(newPath)
+		if err != nil {
+			t.Fatalf("loadProcessorConfig: %v", err)
+		}
+		return p.applyModelGatewayConfig(newCfg, testLogger(t))
+	}
+
+	// First swap: add m2.
+	if err := apply(t, map[string]string{"m1": "http://a:8000", "m2": "http://b:8000"}); err != nil {
+		t.Fatalf("apply (add m2): %v", err)
+	}
+	rs := p.routingState()
+	if rs.resolver.ClientFor("m2") == nil {
+		t.Fatal("added model m2 must resolve after the swap")
+	}
+	if rs.resolver.ClientFor("m1") == nil {
+		t.Fatal("kept model m1 must still resolve after the swap")
+	}
+	first := rs
+
+	// No-op swap: same gateway set must not replace the snapshot.
+	if err := apply(t, map[string]string{"m1": "http://a:8000", "m2": "http://b:8000"}); err != nil {
+		t.Fatalf("apply (no-op): %v", err)
+	}
+	if got := p.routing.Load(); got != first {
+		t.Fatalf("no-op reload replaced the routing snapshot (%p -> %p)", first, got)
+	}
+
+	// Second swap: remove m1. The removed model stops resolving — queued
+	// jobs for it surface model_not_found via the existing preprocessor /
+	// dispatcher ClientFor==nil paths (no new error plumbing needed).
+	if err := apply(t, map[string]string{"m2": "http://b:8000"}); err != nil {
+		t.Fatalf("apply (remove m1): %v", err)
+	}
+	rs = p.routingState()
+	if rs.resolver.ClientFor("m1") != nil {
+		t.Fatal("removed model m1 must stop resolving after the swap")
+	}
+	if rs.resolver.ClientFor("m2") == nil {
+		t.Fatal("kept model m2 must still resolve after the swap")
+	}
+
+	// Endpoint limiter for the unchanged endpoint carries over (AIMD state).
+	oldLimit := first.endpointLimits[first.resolver.ClientFor("m2")]
+	if got := rs.endpointLimits[rs.resolver.ClientFor("m2")]; got != oldLimit {
+		t.Fatal("limiter for unchanged endpoint did not survive the swap")
+	}
+}
+
+func TestApplyModelGatewayConfigBadConfigKeepsState(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeGatewayConfig(t, cfgPath, map[string]string{"m1": "http://a:8000"})
+	p := newReloadTestProcessor(t, cfgPath, 0)
+
+	before := p.routingState()
+
+	// api_key_file points at a nonexistent path: gateway validate/resolve
+	// fails, the old routing must stay in place.
+	badPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `model_gateways:
+  m1:
+    url: "http://a:8000"
+    api_key_file: "/nonexistent/secret"
+    request_timeout: 30s
+    max_retries: 1
+    initial_backoff: 1s
+    max_backoff: 5s
+`
+	if err := os.WriteFile(badPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	newCfg, err := loadProcessorConfig(badPath)
+	if err == nil {
+		if err := p.applyModelGatewayConfig(newCfg, testLogger(t)); err == nil {
+			t.Fatal("apply with unreadable api_key_file must fail")
+		}
+	}
+	if got := p.routingState(); got.resolver != before.resolver || got.endpointLimits == nil && before.endpointLimits != nil {
+		t.Fatal("failed reload must keep the old routing state")
+	}
+	if got := p.routingState(); got.resolver.ClientFor("m1") == nil {
+		t.Fatal("failed reload removed model m1 from routing")
+	}
+}
+
+// TestModelGatewayWatchLoop exercises the polling watcher end to end:
+// change detection, atomic swap (models flipped), bad config tolerated,
+// missing file tolerated, and graceful shutdown via context cancel.
+func TestModelGatewayWatchLoop(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeGatewayConfig(t, cfgPath, map[string]string{"m1": "http://a:8000"})
+	p := newReloadTestProcessor(t, cfgPath, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(testLoggerCtx(t))
+	defer cancel()
+	go p.modelGatewayWatchLoop(ctx)
+
+	// Let the watcher a few poll cycles to anchor its initial content hash
+	// before the first edit below.
+	time.Sleep(100 * time.Millisecond)
+
+	waitFor := func(t *testing.T, desc string, cond func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if cond() {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatalf("timed out waiting for: %s", desc)
+	}
+
+	// Flip the model set: remove m1, add m2.
+	writeGatewayConfig(t, cfgPath, map[string]string{"m2": "http://b:8000"})
+	waitFor(t, "reloaded routing with m2", func() bool {
+		rs := p.routing.Load()
+		return rs != nil && rs.resolver.ClientFor("m2") != nil && rs.resolver.ClientFor("m1") == nil
+	})
+
+	// Corrupt the file: routing stays on the last good snapshot.
+	good := p.routingState()
+	if err := os.WriteFile(cfgPath, []byte("model_gateways: [not, a, map\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond) // a few poll cycles
+	if got := p.routingState().resolver; got != good.resolver {
+		t.Fatal("corrupt config must not replace routing")
+	}
+
+	// Delete the file entirely: tolerated, routing preserved.
+	if err := os.Remove(cfgPath); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := p.routingState().resolver; got != good.resolver {
+		t.Fatal("missing config file must not replace routing")
+	}
+
+	// Restore a syntactically valid but incomplete config (no gateways):
+	// fails validation, still no swap.
+	writeGatewayConfig(t, cfgPath, map[string]string{})
+	if err := os.WriteFile(cfgPath, []byte("num_workers: 2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := p.routingState().resolver; got != good.resolver {
+		t.Fatal("gateway-less config must not replace routing")
+	}
+
+	// Recover with an updated endpoint for m2.
+	writeGatewayConfig(t, cfgPath, map[string]string{"m2": "http://b2:8000"})
+	waitFor(t, "recovery to m2 with new endpoint", func() bool {
+		rs := p.routing.Load()
+		return rs != nil && rs.resolver.ClientLabel(rs.resolver.ClientFor("m2")) == "http://b2:8000"
+	})
+
+	cancel() // watcher goroutine exits; nothing to assert — just no leaks/hang.
+}
+
+func TestStartModelGatewayWatcherDisabledByDefault(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeGatewayConfig(t, cfgPath, map[string]string{"m1": "http://a:8000"})
+	p := newReloadTestProcessor(t, cfgPath, 0) // zero interval = disabled
+
+	p.startModelGatewayWatcher(context.Background())
+	// No goroutine, no panic, nothing to assert further: a zero-interval
+	// ticker would panic if the watcher had started.
+	time.Sleep(50 * time.Millisecond)
+}

--- a/internal/processor/worker/config_reload_test.go
+++ b/internal/processor/worker/config_reload_test.go
@@ -27,6 +27,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -432,6 +433,93 @@ func TestGatewayFingerprintCoversReferencedFiles(t *testing.T) {
 	writeGatewayConfigWithKeyFile(t, cfgPath, keyB)
 	if fp := fingerprint(t); fp == base {
 		t.Fatal("fingerprint must change when the referenced key file path changes")
+	}
+}
+
+// writeGlobalGatewayConfigWithKeyFile writes a valid global-gateway config
+// whose single gateway reads its API key from the given file.
+func writeGlobalGatewayConfigWithKeyFile(t *testing.T, path, keyFile string) {
+	t.Helper()
+	content := fmt.Sprintf(`global_inference_gateway:
+  url: "http://global:8000"
+  api_key_file: %q
+  request_timeout: 30s
+  max_retries: 1
+  initial_backoff: 1s
+  max_backoff: 5s
+`, keyFile)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+}
+
+// TestGatewayFingerprintCoversGlobalFallbackSecret: ResolveModelGateways
+// falls back to the mounted inference-api-key for the global gateway
+// whenever the explicit key source resolves to an empty string (e.g. an
+// api_key_file whose content is empty). The config layer hashes paths, not
+// contents, so it cannot tell whether the fallback will actually be used —
+// the fallback secret is therefore always part of the referenced file set
+// for a global gateway, and rotating it must move the fingerprint even when
+// a non-empty api_key_file makes the fallback unused at resolve time (one
+// extra hashed file is acceptable conservative behavior). Per-model
+// gateways have no such fallback and must not pull the secret into their
+// file set.
+func TestGatewayFingerprintCoversGlobalFallbackSecret(t *testing.T) {
+	dir := t.TempDir()
+	fallback := filepath.Join(dir, "inference-api-key")
+	if err := os.WriteFile(fallback, []byte("fallback-one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	orig := fallbackSecretPath
+	fallbackSecretPath = fallback
+	defer func() { fallbackSecretPath = orig }()
+
+	keyFile := filepath.Join(dir, "api.key")
+	if err := os.WriteFile(keyFile, []byte("explicit-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeGlobalGatewayConfigWithKeyFile(t, cfgPath, keyFile)
+
+	fingerprint := func(t *testing.T) [32]byte {
+		t.Helper()
+		data, err := os.ReadFile(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := loadProcessorConfig(cfgPath)
+		if err != nil {
+			t.Fatalf("loadProcessorConfig: %v", err)
+		}
+		fp, err := gatewayFingerprint(data, cfg)
+		if err != nil {
+			t.Fatalf("gatewayFingerprint: %v", err)
+		}
+		return fp
+	}
+
+	base := fingerprint(t)
+
+	// Rotate only the fallback secret: the config text and the explicit key
+	// are identical, but the fingerprint must still change — in the real
+	// fallback scenario this is what reloads routing on secret rotation.
+	if err := os.WriteFile(fallback, []byte("fallback-two\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if fp := fingerprint(t); fp == base {
+		t.Fatal("fingerprint must change when the global fallback secret rotates")
+	}
+
+	// Per-model gateways never use the fallback: their referenced file set
+	// must exclude the fallback secret path.
+	writeGatewayConfigWithKeyFile(t, cfgPath, keyFile)
+	perModelCfg, err := loadProcessorConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("loadProcessorConfig: %v", err)
+	}
+	files := referencedGatewayFiles(perModelCfg)
+	if slices.Contains(files, fallback) {
+		t.Fatalf("per-model gateway must not reference the global fallback secret, got %v", files)
 	}
 }
 

--- a/internal/processor/worker/config_reload_test.go
+++ b/internal/processor/worker/config_reload_test.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
 )
@@ -261,8 +263,308 @@ func TestStartModelGatewayWatcherDisabledByDefault(t *testing.T) {
 	writeGatewayConfig(t, cfgPath, map[string]string{"m1": "http://a:8000"})
 	p := newReloadTestProcessor(t, cfgPath, 0) // zero interval = disabled
 
-	p.startModelGatewayWatcher(context.Background())
+	ctx, cancel := context.WithCancel(testLoggerCtx(t))
+	p.startModelGatewayWatcher(ctx)
 	// No goroutine, no panic, nothing to assert further: a zero-interval
 	// ticker would panic if the watcher had started.
 	time.Sleep(50 * time.Millisecond)
+	cancel()
+	p.watcherWG.Wait()
+}
+
+// writeGatewayConfigWithKeyFile writes a valid per-model config whose single
+// gateway reads its API key from the given file.
+func writeGatewayConfigWithKeyFile(t *testing.T, path, keyFile string) {
+	t.Helper()
+	content := fmt.Sprintf(`model_gateways:
+  m1:
+    url: "http://a:8000"
+    api_key_file: %q
+    request_timeout: 30s
+    max_retries: 1
+    initial_backoff: 1s
+    max_backoff: 5s
+`, keyFile)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+}
+
+// TestApplyModelGatewayConfigRejectsRouteKeyMethodChange: route_key_method is
+// static (the resolver key and request-side route key must come from the same
+// method); a reload attempting to change it must fail loudly, not silently
+// split the two sides of the lookup.
+func TestApplyModelGatewayConfigRejectsRouteKeyMethodChange(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeGatewayConfig(t, cfgPath, map[string]string{"m1": "http://a:8000"})
+	p := newReloadTestProcessor(t, cfgPath, 0)
+	before := p.routing.Load()
+
+	cfgText, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(newPath, append([]byte("route_key_method: tenant\n"), cfgText...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	newCfg, err := loadProcessorConfig(newPath)
+	if err != nil {
+		t.Fatalf("loadProcessorConfig: %v", err)
+	}
+	if err := p.applyModelGatewayConfig(newCfg, testLogger(t)); err == nil {
+		t.Fatal("route_key_method change must be rejected")
+	}
+	if got := p.routing.Load(); got != before {
+		t.Fatal("rejected route_key_method change must not swap routing")
+	}
+}
+
+// TestModelGatewayWatchLoopRouteKeyMethodChangeRejected: a route_key_method
+// edit is not hot-reloadable. The watcher must keep the current routing and
+// record a failure on every tick (the applied fingerprint is only updated
+// after a successful reload, so the same rejected content is retried).
+func TestModelGatewayWatchLoopRouteKeyMethodChangeRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeGatewayConfig(t, cfgPath, map[string]string{"m1": "http://a:8000"})
+	p := newReloadTestProcessor(t, cfgPath, 10*time.Millisecond)
+	initial := p.routing.Load()
+
+	failuresBefore := reloadFailureCount(t)
+
+	ctx, cancel := context.WithCancel(testLoggerCtx(t))
+	p.watcherWG.Add(1)
+	go func() {
+		defer p.watcherWG.Done()
+		p.modelGatewayWatchLoop(ctx)
+	}()
+	time.Sleep(100 * time.Millisecond) // anchor initial fingerprint
+
+	// Flip only route_key_method; the gateway set itself is unchanged.
+	text, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, append([]byte("route_key_method: tenant\n"), text...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two failures prove the same rejected content is retried, not skipped.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if reloadFailureCount(t) >= failuresBefore+2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := reloadFailureCount(t); got < failuresBefore+2 {
+		t.Fatalf("reload failure count = %v, want at least %v (rejected reloads must retry the same content)", got, failuresBefore+2)
+	}
+	if got := p.routing.Load(); got != initial {
+		t.Fatal("rejected route_key_method change must keep current routing")
+	}
+
+	cancel()
+	p.watcherWG.Wait()
+}
+
+// TestGatewayFingerprintCoversReferencedFiles: the reload fingerprint must
+// change when an api key file's content rotates (identical config text), and
+// when the config points at a different key file path — the referenced path
+// set itself is hashed too.
+func TestGatewayFingerprintCoversReferencedFiles(t *testing.T) {
+	dir := t.TempDir()
+	keyA := filepath.Join(dir, "a.key")
+	keyB := filepath.Join(dir, "b.key")
+	for _, f := range []string{keyA, keyB} {
+		if err := os.WriteFile(f, []byte("key-one\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	fingerprint := func(t *testing.T) [32]byte {
+		t.Helper()
+		data, err := os.ReadFile(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := loadProcessorConfig(cfgPath)
+		if err != nil {
+			t.Fatalf("loadProcessorConfig: %v", err)
+		}
+		fp, err := gatewayFingerprint(data, cfg)
+		if err != nil {
+			t.Fatalf("gatewayFingerprint: %v", err)
+		}
+		return fp
+	}
+
+	writeGatewayConfigWithKeyFile(t, cfgPath, keyA)
+	base := fingerprint(t)
+
+	// Same config text, rotated key content: must be detected.
+	if err := os.WriteFile(keyA, []byte("key-two\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if fp := fingerprint(t); fp == base {
+		t.Fatal("fingerprint must change when the api key file content rotates")
+	}
+	if err := os.WriteFile(keyA, []byte("key-one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if fp := fingerprint(t); fp != base {
+		t.Fatal("fingerprint must return to its base value when the key content is restored")
+	}
+
+	// Different key file path with identical content: the path set is hashed.
+	writeGatewayConfigWithKeyFile(t, cfgPath, keyB)
+	if fp := fingerprint(t); fp == base {
+		t.Fatal("fingerprint must change when the referenced key file path changes")
+	}
+}
+
+// TestApplyModelGatewayConfigClosesResolverOnFailure: when a reload fails
+// after the new resolver was created (here: endpoint limiter construction),
+// the resolver must be closed, otherwise every failed reload leaks HTTP
+// transports for the rest of the process lifetime.
+func TestApplyModelGatewayConfigClosesResolverOnFailure(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeGatewayConfig(t, cfgPath, map[string]string{"m1": "http://a:8000"})
+	p := newReloadTestProcessor(t, cfgPath, 0)
+	before := p.routing.Load()
+
+	fake := &closableFakeClient{}
+	orig := newSyncResolver
+	newSyncResolver = func(*config.ResolvedGateways, logr.Logger) (*inference.GatewayResolver, error) {
+		return inference.NewSingleClientResolver(fake), nil
+	}
+	defer func() { newSyncResolver = orig }()
+
+	// PerEndpoint=0 makes the new (changed) endpoint's limiter construction
+	// fail after the resolver was built.
+	p.cfg.Concurrency.PerEndpoint = 0
+
+	newPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeGatewayConfig(t, newPath, map[string]string{"m1": "http://b:9000"})
+	newCfg, err := loadProcessorConfig(newPath)
+	if err != nil {
+		t.Fatalf("loadProcessorConfig: %v", err)
+	}
+	if err := p.applyModelGatewayConfig(newCfg, testLogger(t)); err == nil {
+		t.Fatal("apply with unbuildable endpoint limits must fail")
+	}
+	if !fake.closed.Load() {
+		t.Fatal("failed reload must close the resolver it created")
+	}
+	if got := p.routing.Load(); got != before {
+		t.Fatal("failed reload must keep the current routing")
+	}
+}
+
+// TestModelGatewayWatchLoopAPIKeyRotationAndRetry: the watcher fingerprint
+// covers referenced external files, and failed reloads retry the same
+// content instead of waiting for the config text to change again.
+//  1. Rotating the API key file alone (identical config text) reloads routing.
+//  2. Deleting the key file fails reloads while content stays the same;
+//     restoring it makes the very next polls succeed without any config edit.
+func TestModelGatewayWatchLoopAPIKeyRotationAndRetry(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	keyPath := filepath.Join(dir, "api.key")
+	if err := os.WriteFile(keyPath, []byte("key-a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeGatewayConfigWithKeyFile(t, cfgPath, keyPath)
+	p := newReloadTestProcessor(t, cfgPath, 10*time.Millisecond)
+	initial := p.routing.Load()
+
+	ctx, cancel := context.WithCancel(testLoggerCtx(t))
+	p.watcherWG.Add(1)
+	go func() {
+		defer p.watcherWG.Done()
+		p.modelGatewayWatchLoop(ctx)
+	}()
+	time.Sleep(100 * time.Millisecond) // anchor initial fingerprint
+
+	waitFor := func(t *testing.T, desc string, cond func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if cond() {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatalf("timed out waiting for: %s", desc)
+	}
+
+	// Rotate only the key file: config text is identical, but the resolved
+	// client config changed, so routing must swap.
+	if err := os.WriteFile(keyPath, []byte("key-b\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "routing swap after api key rotation", func() bool {
+		return p.routing.Load() != initial
+	})
+	rotated := p.routing.Load()
+
+	// Break the referenced file: validation fails. Polls must keep failing
+	// against the same content without ever swapping.
+	if err := os.Remove(keyPath); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if got := p.routing.Load(); got != rotated {
+		t.Fatal("failed reloads must keep the current routing")
+	}
+
+	// Restore the key file with yet another value: the retry must pick it up
+	// without the config text ever changing.
+	if err := os.WriteFile(keyPath, []byte("key-c\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "retry after referenced-file restore", func() bool {
+		return p.routing.Load() != rotated
+	})
+
+	cancel()
+	p.watcherWG.Wait()
+}
+
+type closableFakeClient struct {
+	fakeInferenceClient
+	closed atomic.Bool
+}
+
+func (c *closableFakeClient) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+// TestStopClosesReloadedResolver: the startup resolver is owned and closed by
+// the Clientset; a resolver installed by a config reload must be closed by
+// the processor itself on shutdown, or its HTTP transports leak.
+func TestStopClosesReloadedResolver(t *testing.T) {
+	clients := validProcessorClients(t)
+	p, err := NewProcessor(config.NewConfig(), clients, "test-processor", testLogger(t))
+	if err != nil {
+		t.Fatalf("NewProcessor: %v", err)
+	}
+
+	// No reload ever happened: snapshot resolver == startup resolver, which
+	// the Clientset owns — Stop must not close it here.
+	startup := inference.NewSingleClientResolver(&fakeInferenceClient{})
+	p.inference = startup
+	p.routing.Store(&routingSnapshot{resolver: startup})
+	p.Stop(t.Context())
+
+	// After a reload, the swap target is processor-owned: Stop closes it.
+	reloaded := &closableFakeClient{}
+	p.routing.Store(&routingSnapshot{resolver: inference.NewSingleClientResolver(reloaded)})
+	p.Stop(t.Context())
+	if !reloaded.closed.Load() {
+		t.Fatal("Stop must close the reloaded routing resolver")
+	}
 }

--- a/internal/processor/worker/config_reload_test.go
+++ b/internal/processor/worker/config_reload_test.go
@@ -18,7 +18,13 @@ package worker
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -79,13 +85,17 @@ func newReloadTestProcessor(t *testing.T, cfgPath string, interval time.Duration
 		t.Fatalf("buildEndpointLimits: %v", err)
 	}
 	globalObjective, modelObjectives := objectivesFromConfig(cfg)
-	p.routing.Store(&routingSnapshot{
+	snapshot := &routingSnapshot{
 		resolver:        resolver,
 		endpointLimits:  limits,
 		globalObjective: globalObjective,
 		modelObjectives: modelObjectives,
 		gateways:        resolved,
-	})
+	}
+	if filesHash, err := referencedFilesHash(cfg); err == nil {
+		snapshot.referencedFilesHash = &filesHash
+	}
+	p.routing.Store(snapshot)
 	return p
 }
 
@@ -531,6 +541,162 @@ func TestModelGatewayWatchLoopAPIKeyRotationAndRetry(t *testing.T) {
 
 	cancel()
 	p.watcherWG.Wait()
+}
+
+// writeTestCACert writes a fresh self-signed CA certificate (valid PEM,
+// loadable by the resolver's TLS setup) to path. serial and commonName vary
+// the file content between calls, simulating a certificate rotation.
+func writeTestCACert(t *testing.T, path string, serial int64, commonName string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA certificate: %v", err)
+	}
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write CA cert: %v", err)
+	}
+}
+
+// writeGatewayConfigWithTLS writes a valid per-model config whose single
+// gateway trusts the given CA certificate file and (optionally) reads its
+// API key from keyFile.
+func writeGatewayConfigWithTLS(t *testing.T, path, caCertFile, keyFile string) {
+	t.Helper()
+	keyLine := ""
+	if keyFile != "" {
+		keyLine = fmt.Sprintf("    api_key_file: %q\n", keyFile)
+	}
+	content := fmt.Sprintf(`model_gateways:
+  m1:
+    url: "https://a:8000"
+    tls_ca_cert_file: %q
+%s    request_timeout: 30s
+    max_retries: 1
+    initial_backoff: 1s
+    max_backoff: 5s
+`, caCertFile, keyLine)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+}
+
+// TestApplyModelGatewayConfigTLSRotation: TLS files are referenced by path
+// in GatewayClientConfig, so rotating the certificate content in place
+// leaves the resolved gateway set byte-identical. The snapshot's referenced
+// files digest must still force a resolver rebuild — a genuine no-op must
+// not.
+func TestApplyModelGatewayConfigTLSRotation(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	writeTestCACert(t, caPath, 1, "ca-one")
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeGatewayConfigWithTLS(t, cfgPath, caPath, "")
+	p := newReloadTestProcessor(t, cfgPath, 0)
+
+	apply := func(t *testing.T) {
+		t.Helper()
+		newCfg, err := loadProcessorConfig(cfgPath)
+		if err != nil {
+			t.Fatalf("loadProcessorConfig: %v", err)
+		}
+		if err := p.applyModelGatewayConfig(newCfg, testLogger(t)); err != nil {
+			t.Fatalf("applyModelGatewayConfig: %v", err)
+		}
+	}
+
+	// Pure no-op: nothing changed — the snapshot must be kept.
+	before := p.routing.Load()
+	apply(t)
+	if got := p.routing.Load(); got != before {
+		t.Fatal("unchanged config must not replace the routing snapshot")
+	}
+
+	// Content-only rotation at the same path: config equality can't see it,
+	// the referenced-files digest must.
+	writeTestCACert(t, caPath, 2, "ca-two")
+	apply(t)
+	rotated := p.routing.Load()
+	if rotated == before {
+		t.Fatal("TLS cert rotation in place must rebuild the routing snapshot")
+	}
+	if rotated.resolver == before.resolver {
+		t.Fatal("TLS cert rotation in place must rebuild the resolver")
+	}
+
+	// Path + content change: also rebuilds (the resolved config differs).
+	caPath2 := filepath.Join(dir, "ca2.pem")
+	writeTestCACert(t, caPath2, 3, "ca-three")
+	writeGatewayConfigWithTLS(t, cfgPath, caPath2, "")
+	apply(t)
+	if got := p.routing.Load(); got == rotated {
+		t.Fatal("TLS cert path change must rebuild the routing snapshot")
+	}
+}
+
+// TestApplyModelGatewayConfigAddsReferencedFile: introducing a new
+// referenced file can leave the resolved gateway set byte-identical (here:
+// an api key file whose trimmed content is the empty key that was used
+// before). The enlarged referenced-file set must still trigger a rebuild —
+// the new file's content now governs future change detection.
+func TestApplyModelGatewayConfigAddsReferencedFile(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	writeTestCACert(t, caPath, 1, "ca-one")
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeGatewayConfigWithTLS(t, cfgPath, caPath, "")
+	p := newReloadTestProcessor(t, cfgPath, 0)
+	before := p.routing.Load()
+
+	keyPath := filepath.Join(dir, "api.key")
+	if err := os.WriteFile(keyPath, []byte("\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeGatewayConfigWithTLS(t, cfgPath, caPath, keyPath)
+
+	newCfg, err := loadProcessorConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("loadProcessorConfig: %v", err)
+	}
+	resolved, err := config.ResolveModelGateways(newCfg)
+	if err != nil {
+		t.Fatalf("ResolveModelGateways: %v", err)
+	}
+	if !resolvedGatewaysEqual(before.gateways, resolved) {
+		t.Fatal("test premise broken: adding an empty api key file must leave the resolved gateway set unchanged")
+	}
+
+	if err := p.applyModelGatewayConfig(newCfg, testLogger(t)); err != nil {
+		t.Fatalf("applyModelGatewayConfig: %v", err)
+	}
+	if got := p.routing.Load(); got == before {
+		t.Fatal("introducing a new referenced file must rebuild the routing snapshot")
+	}
+
+	// Subsequent identical reload stays a no-op.
+	after := p.routing.Load()
+	newCfg, err = loadProcessorConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("loadProcessorConfig: %v", err)
+	}
+	if err := p.applyModelGatewayConfig(newCfg, testLogger(t)); err != nil {
+		t.Fatalf("applyModelGatewayConfig: %v", err)
+	}
+	if got := p.routing.Load(); got != after {
+		t.Fatal("unchanged config after the rebuild must not replace the routing snapshot")
+	}
 }
 
 type closableFakeClient struct {

--- a/internal/processor/worker/execute_pipeline.go
+++ b/internal/processor/worker/execute_pipeline.go
@@ -61,11 +61,16 @@ func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionPar
 	)
 	tracker.AddFailed(modelMap.RejectedCount)
 
+	// The routing snapshot is fixed for the lifetime of the job: a config
+	// reload mid-flight never changes which gateway this job's requests
+	// resolve to.
+	rs := p.routingState()
+
 	source := NewPlanFileSource(PlanFileSourceConfig{
 		InputFile:          files.input,
 		PlansDir:           plansDir,
 		ModelMap:           modelMap,
-		Resolver:           p.inference,
+		Routing:            rs,
 		Cfg:                p.cfg,
 		PassThroughHeaders: params.jobInfo.PassThroughHeaders,
 		SLODeadline:        sloDeadline,
@@ -75,7 +80,7 @@ func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionPar
 
 	// The dispatcher forwards requests for processing.
 	pending := pipeline.NewPendingRequests(modelMap.LineCount)
-	dispatcher, err := p.buildRequestDispatcher(modelMap, pending, params.jobInfo.TenantID, logger)
+	dispatcher, err := p.buildRequestDispatcher(modelMap, pending, rs, params.jobInfo.TenantID, logger)
 	if err != nil {
 		return nil, fmt.Errorf("build dispatcher: %w", err)
 	}
@@ -124,15 +129,15 @@ func classifyOutcome(cause error, counts *openai.BatchRequestCounts, execErr err
 	return execErr
 }
 
-func (p *Processor) buildRequestDispatcher(modelMap *modelMapFile, pending *pipeline.PendingRequests, tenantID string, logger logr.Logger) (pipeline.RequestDispatcher, error) {
+func (p *Processor) buildRequestDispatcher(modelMap *modelMapFile, pending *pipeline.PendingRequests, rs *routingSnapshot, tenantID string, logger logr.Logger) (pipeline.RequestDispatcher, error) {
 	switch {
 	case p.asyncInference != nil:
 		broadcasters := p.broadcasters.forModels(modelMap)
 		async := pipeline.NewAsyncDispatcher(p.asyncInference, broadcasters, pending, logger)
 		return pipeline.NewPreDispatcher(async), nil
 	case p.cfg.Concurrency.AIMD.Enabled:
-		models := buildAIMDModels(modelMap, p.inference, p.endpointLimits, p.cfg.RouteKeyMethod, tenantID)
-		direct := pipeline.NewDirectDispatcher(p.inference, logger)
+		models := buildAIMDModels(modelMap, rs.resolver, rs.endpointLimits, p.cfg.RouteKeyMethod, tenantID)
+		direct := pipeline.NewDirectDispatcher(rs.resolver, logger)
 		aimd, err := pipeline.NewAIMDDispatcher(direct, models, p.cfg.Concurrency.Global, logger)
 		if err != nil {
 			return nil, err
@@ -143,8 +148,8 @@ func (p *Processor) buildRequestDispatcher(modelMap *modelMapFile, pending *pipe
 		// EndpointAIMD.AIMD is nil so recordAIMDSignal is a no-op, but the semaphores
 		// still enforce fixed concurrency limits (global + per-endpoint). Without this,
 		// DirectDispatcher would dispatch all requests as unbounded goroutines.
-		models := buildAIMDModels(modelMap, p.inference, p.endpointLimits, p.cfg.RouteKeyMethod, tenantID)
-		direct := pipeline.NewDirectDispatcher(p.inference, logger)
+		models := buildAIMDModels(modelMap, rs.resolver, rs.endpointLimits, p.cfg.RouteKeyMethod, tenantID)
+		direct := pipeline.NewDirectDispatcher(rs.resolver, logger)
 		aimd, err := pipeline.NewAIMDDispatcher(direct, models, p.cfg.Concurrency.Global, logger)
 		if err != nil {
 			return nil, err

--- a/internal/processor/worker/execute_pipeline.go
+++ b/internal/processor/worker/execute_pipeline.go
@@ -61,10 +61,15 @@ func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionPar
 	)
 	tracker.AddFailed(modelMap.RejectedCount)
 
-	// The routing snapshot is fixed for the lifetime of the job: a config
-	// reload mid-flight never changes which gateway this job's requests
-	// resolve to.
-	rs := p.routingState()
+	// The routing snapshot is fixed for the lifetime of the job: captured by
+	// runJob before ingestion, so preprocessing and execution always share
+	// one routing plane even when a config reload swaps the live state
+	// mid-flight. Tests that invoke execution directly leave it nil, in
+	// which case the live routing state is used.
+	rs := params.routing
+	if rs == nil {
+		rs = p.routingState()
+	}
 
 	source := NewPlanFileSource(PlanFileSourceConfig{
 		InputFile:          files.input,

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -1666,6 +1666,70 @@ func TestRecordE2ELatency(t *testing.T) {
 // Test helpers: metric gathering
 // =====================================================================
 
+// reloadFailureCount reads the model gateway reload counter for
+// result="failed" from the default registry (0 if not yet recorded).
+func reloadFailureCount(t *testing.T) float64 {
+	t.Helper()
+	m := findMetric(t, "batch_processor_model_gateway_reload_total", map[string]string{"result": metrics.ResultFailed})
+	if m == nil {
+		return 0
+	}
+	return m.GetCounter().GetValue()
+}
+
+// TestExecuteJob_UsesPinnedRoutingSnapshot: execution MUST resolve gateway
+// clients from the routing snapshot pinned by runJob at job start
+// (params.routing), not from the processor's live routing state. Reproduces
+// F1's mid-flight reload: after ingestion a config swap replaces the live
+// plane; without pinning, dispatch would resolve against a different plane
+// than the one ingestion validated against.
+func TestExecuteJob_UsesPinnedRoutingSnapshot(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	var liveCalls, pinnedCalls atomic.Int32
+	counting := func(counter *atomic.Int32) func(context.Context, *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+		return func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			counter.Add(1)
+			return &inference.GenerateResponse{
+				RequestID: "server-req-1",
+				Response:  []byte(`{"choices":[{"message":{"content":"hello"}}]}`),
+			}, nil
+		}
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "r1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+		{CustomID: "r2", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	// Live routing resolves through liveMock (post-reload plane).
+	env, jobInfo := setupExecutionJob(t, cfg, &mockInferenceClient{generateFn: counting(&liveCalls)}, requests, map[string]string{"m1": "m1"})
+
+	// The job pinned its snapshot before the reload: pinnedMock stands in for
+	// the gateway plane the job's ingestion phase validated against.
+	pinned := &routingSnapshot{
+		resolver: inference.NewSingleClientResolver(&mockInferenceClient{generateFn: counting(&pinnedCalls)}),
+	}
+
+	counts, err := env.p.executeJob(testLoggerCtx(t), &jobExecutionParams{
+		updater: env.updater,
+		jobInfo: jobInfo,
+		routing: pinned,
+	})
+	if err != nil {
+		t.Fatalf("executeJob: %v", err)
+	}
+	if counts.Completed != 2 {
+		t.Fatalf("Completed = %d, want 2", counts.Completed)
+	}
+	if got := pinnedCalls.Load(); got != 2 {
+		t.Fatalf("pinned snapshot client calls = %d, want 2 (execution must dispatch via the pinned snapshot)", got)
+	}
+	if got := liveCalls.Load(); got != 0 {
+		t.Fatalf("live routing client calls = %d, want 0 (execution must not observe the swapped-in routing)", got)
+	}
+}
+
 func findMetric(t *testing.T, name string, labels map[string]string) *dto.Metric {
 	t.Helper()
 	mfs, err := prometheus.DefaultGatherer.Gather()

--- a/internal/processor/worker/job_execution.go
+++ b/internal/processor/worker/job_execution.go
@@ -39,5 +39,13 @@ type jobExecutionParams struct {
 	eventWatcher *db.BatchEventsChan
 	cancelUser   context.CancelFunc
 
+	// routing is the routing snapshot captured by runJob at job start and
+	// shared by every phase (ingestion, dispatch, collection). A mid-flight
+	// config reload swaps Processor.routing but never this reference, so one
+	// job always resolves gateways, endpoint limits and inference objectives
+	// against the same snapshot. Nil only in tests that drive individual
+	// phases directly; those fall back to the live routing state.
+	routing *routingSnapshot
+
 	requestCounts *openai.BatchRequestCounts
 }

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -172,9 +172,16 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 	defer heartbeatCancel()
 	go p.heartbeat(heartbeatCtx, params.jobItem.ID, func() { abortCause(context.Canceled) })
 
+	// Pin the routing snapshot for the whole job: ingestion validates models
+	// against it and execution resolves clients/objectives from the same
+	// snapshot, so a mid-flight config reload cannot split a job across two
+	// routing planes (model accepted at ingest but gone at dispatch, or
+	// objective A at ingest and objective B on the wire).
+	params.routing = p.routingState()
+
 	// ingestion: pre-process job (rejects unregistered-model requests early)
 	ingestCtx, ingestSpan := uotel.StartSpan(abortCtx, "ingest-and-plan")
-	err = p.preProcessJob(ingestCtx, params.jobInfo)
+	err = p.preProcessJob(ingestCtx, params.jobInfo, params.routing)
 	if err != nil && !batchctx.IsTerminal(err) {
 		ingestSpan.RecordError(err)
 		ingestSpan.SetStatus(codes.Error, "pre-process failed")

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -48,7 +48,11 @@ import (
 // error entries for requests targeting unregistered models.
 // The rejected count is persisted in model_map.json so executeJob can
 // seed BatchRequestCounts.Failed without an extra parameter.
-func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobInfo) (err error) {
+//
+// rs is the routing snapshot pinned for this job; nil means "read the
+// processor's current routing" which is only how unit tests drive this
+// phase without a full runJob lifecycle.
+func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobInfo, rs *routingSnapshot) (err error) {
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(logging.INFO).Info("Pre-processing job") // job id is in the logger already
 
@@ -120,7 +124,9 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 	// (treat as non-per-model). Production paths hit Processor.validate() in
 	// prepare() before work runs. The guard also avoids panicking if a future
 	// caller wires a nil resolver.
-	rs := p.routingState()
+	if rs == nil {
+		rs = p.routingState()
+	}
 	isPerModelGateway := rs != nil && rs.resolver != nil && !rs.resolver.IsGlobal()
 	registeredModels := make(map[string]bool) // route key -> registered (per-model only)
 

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -112,11 +112,16 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 	// In per-model mode, check each model against the resolver and reject
 	// unregistered models early. In global mode, all models are routed to
 	// the same endpoint so no check is needed.
-	// p.inference != nil: NewProcessor does not validate clients; unit tests often
-	// call preProcessJob without Run() and omit Inference (treat as non-per-model).
-	// Production paths hit Processor.validate() in prepare() before work runs.
-	// The guard also avoids panicking if a future caller wires a nil resolver.
-	isPerModelGateway := p.inference != nil && !p.inference.IsGlobal()
+	// The routing snapshot is taken once per job — a mid-job config reload
+	// never changes this job's routing; queued jobs for a removed model hit
+	// the model_not_found path below when they are picked up next.
+	// rs != nil && rs.resolver != nil: NewProcessor does not validate clients;
+	// unit tests often call preProcessJob without Run() and omit Inference
+	// (treat as non-per-model). Production paths hit Processor.validate() in
+	// prepare() before work runs. The guard also avoids panicking if a future
+	// caller wires a nil resolver.
+	rs := p.routingState()
+	isPerModelGateway := rs != nil && rs.resolver != nil && !rs.resolver.IsGlobal()
 	registeredModels := make(map[string]bool) // route key -> registered (per-model only)
 
 	// Always truncate error.jsonl at the start of ingestion so that re-enqueued
@@ -183,7 +188,7 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 			lookupID := routeKey(p.cfg.RouteKeyMethod, jobInfo.TenantID, requestMeta.ModelID)
 			registered, checked := registeredModels[lookupID]
 			if !checked {
-				registered = p.inference.ClientFor(lookupID) != nil
+				registered = rs.resolver.ClientFor(lookupID) != nil
 				registeredModels[lookupID] = registered
 			}
 			if !registered {

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -103,7 +103,7 @@ func TestPreProcess_BuildsPlansAndModelMap_OffsetsCorrect(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	if err := p.preProcessJob(ctx, jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo, nil); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -252,7 +252,7 @@ func TestPreProcess_SystemPrompts_PrefixHashAndSortOrder(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	if err := p.preProcessJob(ctx, jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo, nil); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -476,7 +476,7 @@ func TestPreProcess_CancelFlag_ReturnsErrCancelled(t *testing.T) {
 
 	cancelCtx, cancel := context.WithCancelCause(ctx)
 	cancel(batchctx.ErrCancelled)
-	err = p.preProcessJob(cancelCtx, jobInfo)
+	err = p.preProcessJob(cancelCtx, jobInfo, nil)
 	if !errors.Is(err, batchctx.ErrCancelled) {
 		t.Fatalf("expected batchctx.ErrCancelled, got: %v", err)
 	}
@@ -500,7 +500,7 @@ func TestPreProcess_GenuineErrorNotMaskedByCancel(t *testing.T) {
 		BatchJob: &openai.Batch{BatchSpec: openai.BatchSpec{InputFileID: ""}},
 	}
 
-	err := p.preProcessJob(ctx, jobInfo)
+	err := p.preProcessJob(ctx, jobInfo, nil)
 	if err == nil {
 		t.Fatal("expected an error for empty input file ID")
 	}
@@ -583,7 +583,7 @@ func TestPreProcess_CancelBeforeSIGTERM_ReturnsErrCancelled(t *testing.T) {
 	cancelUser(batchctx.ErrCancelled)  // user cancel first
 	tripShutdown(batchctx.ErrShutdown) // SIGTERM second — no-op on the already-cancelled inner layer
 
-	err = p.preProcessJob(cancelCtx, jobInfo)
+	err = p.preProcessJob(cancelCtx, jobInfo, nil)
 	if !errors.Is(err, batchctx.ErrCancelled) {
 		t.Fatalf("expected batchctx.ErrCancelled when user cancel is recorded before SIGTERM, got: %v", err)
 	}
@@ -653,7 +653,7 @@ func TestPreProcess_SLOExpiredDuringIngestion_ReturnsErrExpired(t *testing.T) {
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(-1*time.Second))
 	defer sloCancel()
 
-	err = p.preProcessJob(sloCtx, jobInfo)
+	err = p.preProcessJob(sloCtx, jobInfo, nil)
 	if !errors.Is(err, batchctx.ErrExpired) {
 		t.Fatalf("expected batchctx.ErrExpired, got: %v", err)
 	}
@@ -1401,7 +1401,7 @@ func TestPreProcess_StreamTrue_FailsJob(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	err = p.preProcessJob(ctx, jobInfo)
+	err = p.preProcessJob(ctx, jobInfo, nil)
 	if err == nil {
 		t.Fatal("expected preProcessJob to fail for input with stream: true")
 	}
@@ -1468,7 +1468,7 @@ func TestPreProcess_DuplicateCustomID_FailsJob(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	err = p.preProcessJob(ctx, jobInfo)
+	err = p.preProcessJob(ctx, jobInfo, nil)
 	if err == nil {
 		t.Fatal("expected preProcessJob to fail for duplicate custom_id")
 	}
@@ -1538,7 +1538,7 @@ func TestPreProcess_UniqueCustomIDs_Succeeds(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	if err := p.preProcessJob(ctx, jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo, nil); err != nil {
 		t.Fatalf("expected preProcessJob to succeed with unique custom_ids, got: %v", err)
 	}
 }
@@ -1616,7 +1616,7 @@ func TestPreProcess_UnregisteredModel_RejectedToErrorFile(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	if err := p.preProcessJob(ctx, jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo, nil); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1735,7 +1735,7 @@ func TestPreProcess_AllRequestsUnregistered_ExecuteJobCounts(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	if err := p.preProcessJob(ctx, jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo, nil); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1870,7 +1870,7 @@ func TestPreProcess_ReEnqueue_TruncatesStaleErrorFile(t *testing.T) {
 		t.Fatalf("WriteFile stale error: %v", err)
 	}
 
-	if err := p.preProcessJob(ctx, jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo, nil); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1955,7 +1955,7 @@ func TestPreProcess_ModelNotFound_ThenEarlySLO_PreservesErrorFile(t *testing.T) 
 	}
 
 	// Run ingestion — should reject model-b and write to error.jsonl.
-	if err := p.preProcessJob(ctx, jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo, nil); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1996,5 +1996,101 @@ func TestPreProcess_ModelNotFound_ThenEarlySLO_PreservesErrorFile(t *testing.T) 
 	}
 	if !bytes.Contains(errorBytesAfter, []byte(`"batch_expired"`)) {
 		t.Fatalf("error file missing batch_expired entry for undispatched request:\n%s", errorBytesAfter)
+	}
+}
+
+// TestPreProcessJob_UsesPinnedRoutingSnapshot: ingestion must resolve models
+// against the snapshot pinned for the job, not the processor's live routing
+// state. A mid-flight reload that adds/removes models must not change which
+// requests this job accepts (they are rejected/written to error.jsonl per
+// the pinned view), otherwise preprocessing and execution could split the
+// job across two routing planes.
+func TestPreProcessJob_UsesPinnedRoutingSnapshot(t *testing.T) {
+	ctx := testLoggerCtx(t)
+
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+	filesClient := mockfiles.NewMockBatchFilesClient(t.TempDir())
+	fileDBClient := newMockFileDBClient()
+
+	tenantID := uniqueTestFolder(t, "tenantA/job-inputs")
+	folder, err := ucom.GetFolderNameByTenantID(tenantID)
+	if err != nil {
+		t.Fatalf("GetFolderNameByTenantID: %v", err)
+	}
+	lines := makeInputLines([]string{"m1", "m2"})
+	var remoteBuf bytes.Buffer
+	for _, ln := range lines {
+		remoteBuf.Write(ln)
+	}
+	inputFileID := "file-pinned"
+	if _, err := filesClient.Store(ctx, ucom.FileStorageName(inputFileID, "input.jsonl"), folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+		t.Fatalf("files.Store: %v", err)
+	}
+	fileItem := &db.FileItem{
+		BaseIndexes:  db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
+		BaseContents: db.BaseContents{Spec: mustJSON(t, &openai.FileObject{Filename: "input.jsonl"})},
+	}
+	if err := fileDBClient.DBStore(ctx, fileItem); err != nil {
+		t.Fatalf("DBStore: %v", err)
+	}
+
+	// Live routing knows only m1; the job was pinned to an older snapshot
+	// that only knows m2.
+	liveResolver := inference.NewPerModelClientResolver(map[string]inference.InferenceClient{
+		"m1": &fakeInferenceClient{},
+	})
+	p := mustNewProcessor(t, cfg, &clientset.Clientset{
+		BatchDB:   newMockBatchDBClient(),
+		FileDB:    fileDBClient,
+		File:      filesClient,
+		Inference: liveResolver,
+	})
+
+	pinnedResolver := inference.NewPerModelClientResolver(map[string]inference.InferenceClient{
+		"m2": &fakeInferenceClient{},
+	})
+	pinned := &routingSnapshot{resolver: pinnedResolver}
+
+	jobID := "job-pinned"
+	jobInfo := &batch_types.JobInfo{
+		JobID:    jobID,
+		TenantID: tenantID,
+		BatchJob: &openai.Batch{
+			ID:        jobID,
+			BatchSpec: openai.BatchSpec{InputFileID: inputFileID},
+		},
+	}
+	if err := p.preProcessJob(ctx, jobInfo, pinned); err != nil {
+		t.Fatalf("preProcessJob: %v", err)
+	}
+
+	rootDir, err := p.jobRootDir(jobID, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modelMap, err := readModelMap(rootDir)
+	if err != nil {
+		t.Fatalf("readModelMap: %v", err)
+	}
+	if modelMap.RejectedCount != 1 {
+		t.Fatalf("RejectedCount = %d, want 1 (m1 absent from pinned snapshot)", modelMap.RejectedCount)
+	}
+	for _, modelID := range modelMap.SafeToModel {
+		if modelID != "m2" {
+			t.Fatalf("plan contains %q, want only m2 from the pinned snapshot", modelID)
+		}
+	}
+
+	errorPath, err := p.jobErrorFilePath(jobID, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	errorBytes, err := os.ReadFile(errorPath)
+	if err != nil {
+		t.Fatalf("read error file: %v", err)
+	}
+	if !bytes.Contains(errorBytes, []byte(`"model_not_found"`)) {
+		t.Fatalf("error file must carry model_not_found for m1:\n%s", errorBytes)
 	}
 }

--- a/internal/processor/worker/routing.go
+++ b/internal/processor/worker/routing.go
@@ -27,6 +27,7 @@ limitations under the License.
 package worker
 
 import (
+	"crypto/sha256"
 	"maps"
 	"slices"
 	"time"
@@ -55,6 +56,17 @@ type routingSnapshot struct {
 	// Nil for bootstrap snapshots synthesized before Run() initializes
 	// routing (e.g. unit tests that call job steps without Run).
 	gateways *config.ResolvedGateways
+
+	// referencedFilesHash digests the path set and contents of every
+	// external file the gateway config references (api key and TLS
+	// material). GatewayClientConfig carries TLS cert/key paths only, not
+	// contents, so gateway-set equality cannot see a certificate rotated in
+	// place — without this digest a content-only rotation would be
+	// misjudged as a no-op and the applied fingerprint would pin the stale
+	// TLS material forever. Nil when it could not be computed (the startup
+	// baseline is best-effort); a nil stored digest falls back to
+	// gateway-set equality only and never vetoes a reload.
+	referencedFilesHash *[sha256.Size]byte
 }
 
 // objectiveFor returns the inference objective for the given lookup key
@@ -150,9 +162,17 @@ func (p *Processor) buildEndpointLimits(
 // resolver's clients for closure after a grace period, letting in-flight
 // jobs drain. (HTTPClient.Close closes idle connections only; it never
 // interrupts in-flight requests.)
+//
+// Ownership boundary: the startup resolver (p.inference, installed by
+// initConcurrencyControls) belongs to the Clientset, which closes it in
+// procClients.Close() on shutdown — a swap must never schedule its closure,
+// or the first reload would close it twice and out of Clientset ownership.
+// Resolvers created by config reloads belong to the Processor: the replaced
+// one is closed here after the grace period, and the still-installed one is
+// closed by Stop (closeReloadedRouting).
 func (p *Processor) swapRouting(newSnapshot *routingSnapshot, gracePeriod time.Duration, logger logr.Logger) {
 	old := p.routing.Swap(newSnapshot)
-	if old == nil || old.resolver == nil {
+	if old == nil || old.resolver == nil || old.resolver == p.inference {
 		return
 	}
 	time.AfterFunc(gracePeriod, func() {

--- a/internal/processor/worker/routing.go
+++ b/internal/processor/worker/routing.go
@@ -64,8 +64,10 @@ type routingSnapshot struct {
 	// place — without this digest a content-only rotation would be
 	// misjudged as a no-op and the applied fingerprint would pin the stale
 	// TLS material forever. Nil when it could not be computed (the startup
-	// baseline is best-effort); a nil stored digest falls back to
-	// gateway-set equality only and never vetoes a reload.
+	// baseline is best-effort); nil is "unknown", never "unchanged" — the
+	// next reload forces one resolver rebuild and anchors the computed
+	// digest, so an unreadable-at-startup file cannot permanently stick
+	// change detection in the no-op state.
 	referencedFilesHash *[sha256.Size]byte
 }
 

--- a/internal/processor/worker/routing.go
+++ b/internal/processor/worker/routing.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Hot-reloadable routing plane for model gateway resolution.
+//
+// The sync-dispatch routing plane (resolver + per-endpoint concurrency
+// limits + inference-objective lookup) is captured in an immutable
+// routingSnapshot held behind an atomic pointer on the Processor. Every
+// job takes the snapshot at job start, so an in-flight job never observes
+// a mid-flight routing change; jobs started after a swap resolve against
+// the new config. See config_reload.go for the file watcher that swaps the
+// snapshot.
+
+package worker
+
+import (
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/metrics"
+	"github.com/llm-d/llm-d-batch-gateway/internal/util/logging"
+	"github.com/llm-d/llm-d-batch-gateway/internal/util/semaphore"
+	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
+)
+
+// routingSnapshot is the immutable, atomically swapped routing plane.
+// All fields are read-only after construction — safe for concurrent reads.
+type routingSnapshot struct {
+	resolver       *inference.GatewayResolver
+	endpointLimits map[inference.InferenceClient]*endpointLimit
+
+	// inference-objective lookup mirrors ProcessorConfig.InferenceObjectiveFor
+	// for the gateway set captured by this snapshot.
+	globalObjective string
+	modelObjectives map[string]string
+
+	// gateways is the resolved gateway baseline this snapshot was built
+	// from. Used by the reload path to diff and to skip no-op swaps.
+	// Nil for bootstrap snapshots synthesized before Run() initializes
+	// routing (e.g. unit tests that call job steps without Run).
+	gateways *config.ResolvedGateways
+}
+
+// objectiveFor returns the inference objective for the given lookup key
+// (the route key used for gateway resolution), or "" when none is
+// configured — mirroring ProcessorConfig.InferenceObjectiveFor.
+func (s *routingSnapshot) objectiveFor(modelID string) string {
+	if s == nil || s.resolver == nil {
+		return ""
+	}
+	if s.resolver.IsGlobal() {
+		return s.globalObjective
+	}
+	return s.modelObjectives[modelID]
+}
+
+// objectivesFromConfig mirrors ProcessorConfig.InferenceObjectiveFor as a
+// snapshot-friendly (global, per-model) pair.
+func objectivesFromConfig(cfg *config.ProcessorConfig) (string, map[string]string) {
+	if cfg.GlobalInferenceGateway != nil {
+		return cfg.GlobalInferenceGateway.InferenceObjective, nil
+	}
+	modelObjectives := make(map[string]string, len(cfg.ModelGateways))
+	for model, gw := range cfg.ModelGateways {
+		modelObjectives[model] = gw.InferenceObjective
+	}
+	return "", modelObjectives
+}
+
+// routingState returns the current routing snapshot. Before Run() stores
+// one (unit tests, recovery pre-Run steps), it falls back to a bootstrap
+// snapshot synthesized from the startup resolver and static config.
+func (p *Processor) routingState() *routingSnapshot {
+	if s := p.routing.Load(); s != nil {
+		return s
+	}
+	globalObjective, modelObjectives := objectivesFromConfig(p.cfg)
+	return &routingSnapshot{
+		resolver:        p.inference,
+		endpointLimits:  p.endpointLimits,
+		globalObjective: globalObjective,
+		modelObjectives: modelObjectives,
+	}
+}
+
+// buildEndpointLimits creates a per-endpoint concurrency limiter for every
+// unique client in the resolver. Unchanged endpoints (matched by URL label)
+// reuse their previous limiter so learned AIMD state survives a reload.
+func (p *Processor) buildEndpointLimits(
+	resolver *inference.GatewayResolver,
+	prev map[inference.InferenceClient]*endpointLimit,
+	logger logr.Logger,
+) (map[inference.InferenceClient]*endpointLimit, error) {
+	cc := &p.cfg.Concurrency
+
+	prevByLabel := make(map[string]*endpointLimit, len(prev))
+	for _, ep := range prev {
+		prevByLabel[ep.label] = ep
+	}
+
+	clients := resolver.Clients()
+	limits := make(map[inference.InferenceClient]*endpointLimit, len(clients))
+	for _, client := range clients {
+		epLabel := resolver.ClientLabel(client)
+		if ep, ok := prevByLabel[epLabel]; ok {
+			limits[client] = ep
+			continue
+		}
+		epSem, err := semaphore.NewAdaptive(cc.PerEndpoint, p.makeGuard("endpoint-concurrency"))
+		if err != nil {
+			return nil, err
+		}
+		var epAIMD *semaphore.AIMDController
+		if cc.AIMD.Enabled {
+			epAIMD = semaphore.NewAIMDController(
+				semaphore.AIMDConfig{
+					MinLimit:         cc.AIMD.Min,
+					MaxLimit:         cc.PerEndpoint,
+					BackoffFactor:    cc.AIMD.BackoffFactor,
+					AdditiveIncrease: cc.AIMD.AdditiveIncrease,
+				},
+				cc.PerEndpoint,
+				func(limit int) { epSem.SetLimit(limit) },
+				logger.WithValues("endpoint", epLabel),
+			)
+			metrics.SetAIMDConcurrencyLimit(epLabel, float64(cc.PerEndpoint))
+		}
+		limits[client] = &endpointLimit{sem: epSem, aimd: epAIMD, label: epLabel}
+	}
+	return limits, nil
+}
+
+// swapRouting atomically replaces the routing plane and schedules the old
+// resolver's clients for closure after a grace period, letting in-flight
+// jobs drain. (HTTPClient.Close closes idle connections only; it never
+// interrupts in-flight requests.)
+func (p *Processor) swapRouting(newSnapshot *routingSnapshot, gracePeriod time.Duration, logger logr.Logger) {
+	old := p.routing.Swap(newSnapshot)
+	if old == nil || old.resolver == nil {
+		return
+	}
+	time.AfterFunc(gracePeriod, func() {
+		_ = old.resolver.Close()
+		logger.V(logging.INFO).Info("Closed replaced model gateway clients after grace period",
+			"gracePeriod", gracePeriod)
+	})
+}
+
+// resolvedGatewaysEqual reports whether two resolved gateway sets produce
+// an identical routing plane. Async dispatch mode is never a valid reload
+// target, so Async equality reduces to both-nil.
+func resolvedGatewaysEqual(a, b *config.ResolvedGateways) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if (a.Global == nil) != (b.Global == nil) {
+		return false
+	}
+	if a.Global != nil && *a.Global != *b.Global {
+		return false
+	}
+	return maps.Equal(a.PerModel, b.PerModel)
+}
+
+// routingDiff computes the per-model routing changes between two resolved
+// gateway sets. Suitable for logging only.
+func routingDiff(old, new *config.ResolvedGateways) (added, removed, updated []string) {
+	for model, gw := range new.PerModel {
+		if old == nil {
+			added = append(added, model)
+			continue
+		}
+		if oldGw, ok := old.PerModel[model]; ok {
+			if oldGw != gw {
+				updated = append(updated, model)
+			}
+		} else {
+			added = append(added, model)
+		}
+	}
+	if old != nil {
+		for model := range old.PerModel {
+			if _, ok := new.PerModel[model]; !ok {
+				removed = append(removed, model)
+			}
+		}
+	}
+	slices.Sort(added)
+	slices.Sort(removed)
+	slices.Sort(updated)
+	return added, removed, updated
+}

--- a/internal/processor/worker/routing_test.go
+++ b/internal/processor/worker/routing_test.go
@@ -18,6 +18,7 @@ package worker
 
 import (
 	"testing"
+	"time"
 
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
@@ -251,4 +252,42 @@ func TestRoutingStateBootstrapFallback(t *testing.T) {
 	if got := rs.objectiveFor("m1"); got != "obj-a" {
 		t.Fatalf("objectiveFor(m1) = %q, want %q", got, "obj-a")
 	}
+}
+
+// TestSwapRoutingCloseOwnership: the startup resolver is owned by the
+// Clientset (closed by procClients.Close() on shutdown), so swapping it out
+// must not schedule a grace close. Resolvers installed by config reloads
+// are Processor-owned: the replaced one is closed after the grace period.
+func TestSwapRoutingCloseOwnership(t *testing.T) {
+	p, err := NewProcessor(config.NewConfig(), validProcessorClients(t), "test-processor", testLogger(t))
+	if err != nil {
+		t.Fatalf("NewProcessor: %v", err)
+	}
+
+	startupClient := &closableFakeClient{}
+	startup := inference.NewSingleClientResolver(startupClient)
+	p.inference = startup
+	p.routing.Store(&routingSnapshot{resolver: startup})
+
+	// First reload swaps the startup resolver out: no close may be
+	// scheduled — the Clientset still owns it.
+	reloadedClient := &closableFakeClient{}
+	p.swapRouting(&routingSnapshot{resolver: inference.NewSingleClientResolver(reloadedClient)}, 20*time.Millisecond, testLogger(t))
+	time.Sleep(100 * time.Millisecond) // several grace periods past
+	if startupClient.closed.Load() {
+		t.Fatal("startup resolver must not be closed by a swap; the Clientset owns it")
+	}
+
+	// A second reload replaces a Processor-owned resolver: its close is
+	// scheduled after the grace period.
+	secondClient := &closableFakeClient{}
+	p.swapRouting(&routingSnapshot{resolver: inference.NewSingleClientResolver(secondClient)}, 20*time.Millisecond, testLogger(t))
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if reloadedClient.closed.Load() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("replaced reload-created resolver must be closed after the grace period")
 }

--- a/internal/processor/worker/routing_test.go
+++ b/internal/processor/worker/routing_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package worker
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
+)
+
+func mustResolver(t *testing.T, urls map[string]string) *inference.GatewayResolver {
+	t.Helper()
+	configs := make(map[string]inference.GatewayClientConfig, len(urls))
+	for model, url := range urls {
+		configs[model] = inference.GatewayClientConfig{URL: url}
+	}
+	resolver, err := inference.NewPerModelResolver(configs, testLogger(t))
+	if err != nil {
+		t.Fatalf("NewPerModelResolver: %v", err)
+	}
+	return resolver
+}
+
+func TestRoutingSnapshotObjectiveFor(t *testing.T) {
+	ptrCfg := func(gw config.ModelGatewayConfig) *config.ProcessorConfig {
+		cfg := config.NewConfig()
+		cfg.GlobalInferenceGateway = &gw
+		return cfg
+	}
+
+	perModel := config.NewConfig()
+	perModel.ModelGateways = map[string]config.ModelGatewayConfig{
+		"m1": {URL: "http://a:8000", InferenceObjective: "obj-a"},
+		"m2": {URL: "http://b:8000"},
+	}
+
+	globalObjective, modelObjectives := objectivesFromConfig(perModel)
+	perModelSnapshot := &routingSnapshot{
+		resolver:        mustResolver(t, map[string]string{"m1": "http://a:8000", "m2": "http://b:8000"}),
+		globalObjective: globalObjective,
+		modelObjectives: modelObjectives,
+	}
+
+	globalCfg := ptrCfg(config.ModelGatewayConfig{URL: "http://g:8000", InferenceObjective: "obj-global"})
+	globalResolver, err := inference.NewGlobalResolver(inference.GatewayClientConfig{URL: "http://g:8000"}, testLogger(t))
+	if err != nil {
+		t.Fatalf("NewGlobalResolver: %v", err)
+	}
+	globalObjective, gModelObjectives := objectivesFromConfig(globalCfg)
+	globalSnapshot := &routingSnapshot{
+		resolver:        globalResolver,
+		globalObjective: globalObjective,
+		modelObjectives: gModelObjectives,
+	}
+
+	tests := []struct {
+		name     string
+		snapshot *routingSnapshot
+		modelID  string
+		want     string
+	}{
+		{name: "per-model hit", snapshot: perModelSnapshot, modelID: "m1", want: "obj-a"},
+		{name: "per-model no objective", snapshot: perModelSnapshot, modelID: "m2", want: ""},
+		{name: "per-model unknown model", snapshot: perModelSnapshot, modelID: "nope", want: ""},
+		{name: "global uses its objective for any model", snapshot: globalSnapshot, modelID: "anything", want: "obj-global"},
+		{name: "nil snapshot", snapshot: nil, modelID: "m1", want: ""},
+		{name: "nil resolver", snapshot: &routingSnapshot{}, modelID: "m1", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.snapshot.objectiveFor(tt.modelID); got != tt.want {
+				t.Fatalf("objectiveFor(%q) = %q, want %q", tt.modelID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvedGatewaysEqual(t *testing.T) {
+	gw := func(url string) inference.GatewayClientConfig {
+		return inference.GatewayClientConfig{URL: url, Timeout: 1, MaxRetries: 1}
+	}
+
+	tests := []struct {
+		name string
+		a, b *config.ResolvedGateways
+		want bool
+	}{
+		{name: "both nil", a: nil, b: nil, want: true},
+		{name: "one nil", a: &config.ResolvedGateways{}, b: nil, want: false},
+		{
+			name: "same per-model set",
+			a:    &config.ResolvedGateways{PerModel: map[string]inference.GatewayClientConfig{"m1": gw("http://a:8000")}},
+			b:    &config.ResolvedGateways{PerModel: map[string]inference.GatewayClientConfig{"m1": gw("http://a:8000")}},
+			want: true,
+		},
+		{
+			name: "different url for same model",
+			a:    &config.ResolvedGateways{PerModel: map[string]inference.GatewayClientConfig{"m1": gw("http://a:8000")}},
+			b:    &config.ResolvedGateways{PerModel: map[string]inference.GatewayClientConfig{"m1": gw("http://b:8000")}},
+			want: false,
+		},
+		{
+			name: "additional model",
+			a:    &config.ResolvedGateways{PerModel: map[string]inference.GatewayClientConfig{"m1": gw("http://a:8000")}},
+			b:    &config.ResolvedGateways{PerModel: map[string]inference.GatewayClientConfig{"m1": gw("http://a:8000"), "m2": gw("http://a:8000")}},
+			want: false,
+		},
+		{
+			name: "global vs per-model",
+			a:    &config.ResolvedGateways{Global: &[]inference.GatewayClientConfig{gw("http://a:8000")}[0]},
+			b:    &config.ResolvedGateways{PerModel: map[string]inference.GatewayClientConfig{"m1": gw("http://a:8000")}},
+			want: false,
+		},
+		{
+			name: "same global",
+			a:    &config.ResolvedGateways{Global: &[]inference.GatewayClientConfig{gw("http://a:8000")}[0]},
+			b:    &config.ResolvedGateways{Global: &[]inference.GatewayClientConfig{gw("http://a:8000")}[0]},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolvedGatewaysEqual(tt.a, tt.b); got != tt.want {
+				t.Fatalf("resolvedGatewaysEqual = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRoutingDiff(t *testing.T) {
+	gw := func(url string) inference.GatewayClientConfig {
+		return inference.GatewayClientConfig{URL: url}
+	}
+	oldSet := &config.ResolvedGateways{PerModel: map[string]inference.GatewayClientConfig{
+		"keep":   gw("http://a:8000"),
+		"gone":   gw("http://b:8000"),
+		"change": gw("http://c:8000"),
+	}}
+	newSet := &config.ResolvedGateways{PerModel: map[string]inference.GatewayClientConfig{
+		"keep":   gw("http://a:8000"),
+		"change": gw("http://c2:8000"),
+		"fresh":  gw("http://d:8000"),
+	}}
+
+	added, removed, updated := routingDiff(oldSet, newSet)
+	if len(added) != 1 || added[0] != "fresh" {
+		t.Fatalf("added = %v, want [fresh]", added)
+	}
+	if len(removed) != 1 || removed[0] != "gone" {
+		t.Fatalf("removed = %v, want [gone]", removed)
+	}
+	if len(updated) != 1 || updated[0] != "change" {
+		t.Fatalf("updated = %v, want [change]", updated)
+	}
+
+	added, removed, updated = routingDiff(nil, newSet)
+	if len(added) != 3 {
+		t.Fatalf("nil baseline: added = %v, want all 3 models", added)
+	}
+	if len(removed) != 0 || len(updated) != 0 {
+		t.Fatalf("nil baseline: removed=%v updated=%v, want empty", removed, updated)
+	}
+}
+
+func TestBuildEndpointLimitsCarryover(t *testing.T) {
+	cfg := config.NewConfig()
+	p, err := NewProcessor(cfg, validProcessorClients(t), "test-processor", testLogger(t))
+	if err != nil {
+		t.Fatalf("NewProcessor: %v", err)
+	}
+	p.makeGuard = func(string) func() { return func() {} }
+
+	oldResolver := mustResolver(t, map[string]string{
+		"m1": "http://a:8000",
+		"m2": "http://b:8000",
+	})
+	limits, err := p.buildEndpointLimits(oldResolver, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("buildEndpointLimits: %v", err)
+	}
+	if len(limits) != 2 {
+		t.Fatalf("got %d limits, want 2", len(limits))
+	}
+	keptClient := oldResolver.ClientFor("m1")
+	keptLimit := limits[keptClient]
+	if keptLimit == nil {
+		t.Fatal("limit for m1 missing")
+	}
+
+	// Reload: m1 unchanged (same URL), m2 moved, m3 added.
+	newResolver := mustResolver(t, map[string]string{
+		"m1": "http://a:8000",
+		"m2": "http://b2:8000",
+		"m3": "http://c:8000",
+	})
+	newLimits, err := p.buildEndpointLimits(newResolver, limits, testLogger(t))
+	if err != nil {
+		t.Fatalf("buildEndpointLimits (reload): %v", err)
+	}
+	if len(newLimits) != 3 {
+		t.Fatalf("got %d limits, want 3", len(newLimits))
+	}
+	if got := newLimits[newResolver.ClientFor("m1")]; got != keptLimit {
+		t.Fatalf("unchanged endpoint did not keep its limiter (learned AIMD state would be lost)")
+	}
+	if got := newLimits[newResolver.ClientFor("m2")]; got == limits[oldResolver.ClientFor("m2")] {
+		t.Fatal("moved endpoint m2 should get a fresh limiter")
+	}
+	if newLimits[newResolver.ClientFor("m3")] == nil {
+		t.Fatal("new endpoint m3 must get a limiter")
+	}
+}
+
+func TestRoutingStateBootstrapFallback(t *testing.T) {
+	resolver := mustResolver(t, map[string]string{"m1": "http://a:8000"})
+	cfg := config.NewConfig()
+	cfg.ModelGateways = map[string]config.ModelGatewayConfig{
+		"m1": {URL: "http://a:8000", InferenceObjective: "obj-a"},
+	}
+	cs := validProcessorClients(t)
+	cs.Inference = resolver
+
+	p, err := NewProcessor(cfg, cs, "test-processor", testLogger(t))
+	if err != nil {
+		t.Fatalf("NewProcessor: %v", err)
+	}
+
+	// Without Run(), routingState falls back to the startup resolver + cfg.
+	rs := p.routingState()
+	if rs == nil || rs.resolver == nil {
+		t.Fatal("routingState() = nil, want bootstrap snapshot")
+	}
+	if rs.resolver.ClientFor("m1") == nil {
+		t.Fatal("bootstrap snapshot must route to the startup resolver")
+	}
+	if got := rs.objectiveFor("m1"); got != "obj-a" {
+		t.Fatalf("objectiveFor(m1) = %q, want %q", got, "obj-a")
+	}
+}

--- a/internal/processor/worker/source_planfile.go
+++ b/internal/processor/worker/source_planfile.go
@@ -17,7 +17,6 @@ import (
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/pipeline"
 	batch_types "github.com/llm-d/llm-d-batch-gateway/internal/shared/types"
-	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
 )
 
 // PlanFileSource reads plan files and input JSONL to produce RequestItems.
@@ -25,7 +24,7 @@ type PlanFileSource struct {
 	inputFile          *os.File
 	plansDir           string
 	modelMap           *modelMapFile
-	resolver           *inference.GatewayResolver
+	routing            *routingSnapshot
 	cfg                *config.ProcessorConfig
 	passThroughHeaders map[string]string
 	sloDeadline        time.Time
@@ -39,7 +38,7 @@ type PlanFileSourceConfig struct {
 	InputFile          *os.File
 	PlansDir           string
 	ModelMap           *modelMapFile
-	Resolver           *inference.GatewayResolver
+	Routing            *routingSnapshot
 	Cfg                *config.ProcessorConfig
 	PassThroughHeaders map[string]string
 	SLODeadline        time.Time
@@ -52,7 +51,7 @@ func NewPlanFileSource(cfg PlanFileSourceConfig) *PlanFileSource {
 		inputFile:          cfg.InputFile,
 		plansDir:           cfg.PlansDir,
 		modelMap:           cfg.ModelMap,
-		resolver:           cfg.Resolver,
+		routing:            cfg.Routing,
 		cfg:                cfg.Cfg,
 		passThroughHeaders: cfg.PassThroughHeaders,
 		sloDeadline:        cfg.SLODeadline,
@@ -139,7 +138,7 @@ func (s *PlanFileSource) mergeHeaders(headers map[string]string, modelID string)
 		}
 	}
 
-	if obj := s.cfg.InferenceObjectiveFor(modelID); obj != "" {
+	if obj := s.inferenceObjective(modelID); obj != "" {
 		headers[inferenceObjectiveHeader] = obj
 	}
 
@@ -150,4 +149,15 @@ func (s *PlanFileSource) mergeHeaders(headers map[string]string, modelID string)
 	}
 
 	return headers
+}
+
+// inferenceObjective returns the objective configured for the given lookup
+// key. The routing snapshot reflects the current (possibly hot-reloaded)
+// gateway config. When no snapshot is wired (unit tests without Run()),
+// fall back to the static config.
+func (s *PlanFileSource) inferenceObjective(modelID string) string {
+	if s.routing != nil {
+		return s.routing.objectiveFor(modelID)
+	}
+	return s.cfg.InferenceObjectiveFor(modelID)
 }

--- a/internal/processor/worker/source_planfile_test.go
+++ b/internal/processor/worker/source_planfile_test.go
@@ -310,7 +310,6 @@ func TestPlanFileSource_Produce(t *testing.T) {
 		InputFile: inputFile,
 		PlansDir:  plansDir,
 		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 2},
-		Resolver:  resolver,
 		Cfg:       config.NewConfig(),
 		Logger:    logr.Discard(),
 	})
@@ -395,7 +394,6 @@ func TestPlanFileSource_Produce_TenantScopedLookup(t *testing.T) {
 		InputFile: inputFile,
 		PlansDir:  plansDir,
 		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 1},
-		Resolver:  resolver,
 		Cfg:       cfg,
 		TenantID:  "inferset-a",
 		Logger:    logr.Discard(),
@@ -437,7 +435,6 @@ func TestPlanFileSource_Produce_TenantScopedLookup(t *testing.T) {
 		InputFile: inputFile2,
 		PlansDir:  plansDir,
 		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 1},
-		Resolver:  resolver,
 		Cfg:       cfgOff,
 		TenantID:  "inferset-a",
 		Logger:    logr.Discard(),
@@ -518,9 +515,8 @@ func TestPlanFileSource_Produce_MultipleModels(t *testing.T) {
 			SafeToModel: map[string]string{"m1": "m1", "m2": "m2"},
 			LineCount:   3,
 		},
-		Resolver: resolver,
-		Cfg:      config.NewConfig(),
-		Logger:   logr.Discard(),
+		Cfg:    config.NewConfig(),
+		Logger: logr.Discard(),
 	})
 
 	out := make(chan pipeline.RequestItem, 10)
@@ -594,7 +590,6 @@ func TestPlanFileSource_Produce_MalformedLine(t *testing.T) {
 		InputFile: inputFile,
 		PlansDir:  plansDir,
 		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 2},
-		Resolver:  resolver,
 		Cfg:       config.NewConfig(),
 		Logger:    logr.Discard(),
 	})
@@ -662,7 +657,6 @@ func TestPlanFileSource_Produce_BadPlanFile(t *testing.T) {
 		InputFile: inputFile,
 		PlansDir:  plansDir,
 		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 1},
-		Resolver:  resolver,
 		Cfg:       config.NewConfig(),
 		Logger:    logr.Discard(),
 	})
@@ -732,7 +726,6 @@ func TestPlanFileSource_Produce_CancellationProducesAllEntries(t *testing.T) {
 		InputFile: inputFile,
 		PlansDir:  plansDir,
 		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: int64(totalRequests)},
-		Resolver:  resolver,
 		Cfg:       config.NewConfig(),
 		Logger:    logr.Discard(),
 	})

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -67,6 +68,22 @@ type Processor struct {
 	// and reuses concrete clients for identical endpoint configs.
 	endpointLimits map[inference.InferenceClient]*endpointLimit
 
+	// routing is the live, atomically swapped routing plane (sync mode).
+	// Set by initConcurrencyControls in Run(); until then, routingState()
+	// falls back to a bootstrap snapshot built from inference +
+	// endpointLimits. See routing.go and config_reload.go.
+	routing atomic.Pointer[routingSnapshot]
+
+	// makeGuard builds the double-release guard for semaphores created
+	// after initConcurrencyControls (e.g. per-endpoint limiters created by
+	// config reload). Nil before Run().
+	makeGuard func(name string) func()
+
+	// gwReloadPath / gwReloadInterval configure hot reload of
+	// model_gateways / global_inference_gateway. Zero interval disables it.
+	gwReloadPath     string
+	gwReloadInterval time.Duration
+
 	poller  *Poller
 	updater *StatusUpdater
 
@@ -79,11 +96,22 @@ type Processor struct {
 	files          *fileManager
 }
 
+// ProcessorOption configures optional Processor features.
+type ProcessorOption func(*Processor)
+
+// WithModelGatewayConfigReload enables hot reload of the model gateway
+// routing plane from the given config file. A zero or negative interval
+// disables the watcher (default).
+func WithModelGatewayConfigReload(configPath string, interval time.Duration) ProcessorOption {
+	return func(p *Processor) { p.gwReloadPath, p.gwReloadInterval = configPath, interval }
+}
+
 func NewProcessor(
 	cfg *config.ProcessorConfig,
 	clients *clientset.Clientset,
 	processorID string,
 	logger logr.Logger,
+	opts ...ProcessorOption,
 ) (*Processor, error) {
 	if cfg.NumWorkers <= 0 {
 		return nil, fmt.Errorf("worker semaphore (NumWorkers=%d): %w", cfg.NumWorkers, semaphore.ErrCap)
@@ -93,7 +121,7 @@ func NewProcessor(
 	}
 	poller := NewPoller(clients.Queue, clients.BatchDB)
 	updater := NewStatusUpdater(clients.BatchDB, clients.Status, cfg.ProgressTTLSeconds)
-	return &Processor{
+	p := &Processor{
 		cfg:            cfg,
 		processorID:    processorID,
 		poller:         poller,
@@ -104,7 +132,11 @@ func NewProcessor(
 		inference:      clients.Inference,
 		asyncInference: clients.AsyncInference,
 		files:          newFileManager(clients.File, clients.FileDB),
-	}, nil
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p, nil
 }
 
 // Run starts processor orchestration and enters the polling loop.
@@ -135,6 +167,11 @@ func (p *Processor) Run(ctx context.Context, onReady func()) error {
 		return err
 	}
 
+	// Start the model gateway config watcher (no-op unless reload is enabled).
+	// Must run after initConcurrencyControls so the routing snapshot exists
+	// and makeGuard is available for reload-created endpoint limiters.
+	p.startModelGatewayWatcher(ctx)
+
 	// If async inference is used (llm-d-async), set up a registry of ResultBroadcasters.
 	// These will propagate results from the async queues to the JobExecutor's individual result collectors.
 	if p.asyncInference != nil {
@@ -154,14 +191,14 @@ func (p *Processor) initConcurrencyControls(logger logr.Logger, stopAccepting co
 	// Create semaphores here (not in NewProcessor) so the double-release guard
 	// callback can capture stopAccepting. This keeps semaphores immutable after
 	// construction — no mutex, no OnDoubleRelease method.
-	makeGuard := func(name string) func() {
+	p.makeGuard = func(name string) func() {
 		return func() {
 			logger.Error(fmt.Errorf("semaphore double-release"), "Initiating graceful shutdown", "semaphore", name)
 			stopAccepting()
 		}
 	}
 	var err error
-	p.tokens, err = semaphore.New(p.cfg.NumWorkers, makeGuard("num-workers"))
+	p.tokens, err = semaphore.New(p.cfg.NumWorkers, p.makeGuard("num-workers"))
 	if err != nil {
 		return fmt.Errorf("worker semaphore (NumWorkers=%d): %w", p.cfg.NumWorkers, err)
 	}
@@ -176,36 +213,30 @@ func (p *Processor) initConcurrencyControls(logger logr.Logger, stopAccepting co
 	}
 
 	cc := &p.cfg.Concurrency
-	p.globalSem, err = semaphore.New(cc.Global, makeGuard("global-concurrency"))
+	p.globalSem, err = semaphore.New(cc.Global, p.makeGuard("global-concurrency"))
 	if err != nil {
 		return fmt.Errorf("global semaphore (concurrency.global=%d): %w", cc.Global, err)
 	}
 
-	clients := p.inference.Clients()
-	p.endpointLimits = make(map[inference.InferenceClient]*endpointLimit, len(clients))
-	for _, client := range clients {
-		epLabel := p.inference.ClientLabel(client)
-		epSem, epErr := semaphore.NewAdaptive(cc.PerEndpoint, makeGuard("endpoint-concurrency"))
-		if epErr != nil {
-			return fmt.Errorf("endpoint semaphore (concurrency.per_endpoint=%d): %w", cc.PerEndpoint, epErr)
-		}
-		var epAIMD *semaphore.AIMDController
-		if cc.AIMD.Enabled {
-			epAIMD = semaphore.NewAIMDController(
-				semaphore.AIMDConfig{
-					MinLimit:         cc.AIMD.Min,
-					MaxLimit:         cc.PerEndpoint,
-					BackoffFactor:    cc.AIMD.BackoffFactor,
-					AdditiveIncrease: cc.AIMD.AdditiveIncrease,
-				},
-				cc.PerEndpoint,
-				func(limit int) { epSem.SetLimit(limit) },
-				logger.WithValues("endpoint", epLabel),
-			)
-			metrics.SetAIMDConcurrencyLimit(epLabel, float64(cc.PerEndpoint))
-		}
-		p.endpointLimits[client] = &endpointLimit{sem: epSem, aimd: epAIMD, label: epLabel}
+	p.endpointLimits, err = p.buildEndpointLimits(p.inference, nil, logger)
+	if err != nil {
+		return fmt.Errorf("endpoint semaphore (concurrency.per_endpoint=%d): %w", cc.PerEndpoint, err)
 	}
+	clients := p.inference.Clients()
+
+	// Publish the initial routing snapshot. This also anchors the reload
+	// baseline: re-resolving the startup config gives the diff/equality
+	// reference for the first config change (best-effort — a missing
+	// secret file just drops diff fidelity for that first reload).
+	routing := p.routingState()
+	routing.endpointLimits = p.endpointLimits
+	if resolved, resolveErr := config.ResolveModelGateways(p.cfg); resolveErr != nil {
+		logger.Error(resolveErr, "Failed to resolve model gateways for reload baseline; first config change will report all models as added")
+	} else {
+		routing.gateways = resolved
+	}
+	p.routing.Store(routing)
+
 	const highCardinalityThreshold = 50
 	if cc.AIMD.Enabled && len(clients) > highCardinalityThreshold {
 		logger.Info("AIMD metrics may cause high cardinality: "+

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -248,7 +248,7 @@ func (p *Processor) initConcurrencyControls(logger logr.Logger, stopAccepting co
 		routing.gateways = resolved
 	}
 	if filesHash, hashErr := referencedFilesHash(p.cfg); hashErr != nil {
-		logger.Error(hashErr, "Failed to hash referenced gateway files for reload baseline; a content-only key/cert rotation applied before the first reload may wait for a further config change")
+		logger.Error(hashErr, "Failed to hash referenced gateway files for reload baseline; the first successful reload will rebuild routing once to anchor the digest")
 	} else {
 		routing.referencedFilesHash = &filesHash
 	}

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -79,6 +79,10 @@ type Processor struct {
 	// config reload). Nil before Run().
 	makeGuard func(name string) func()
 
+	// watcherWG tracks the config-reload watcher goroutine, whose lifecycle
+	// is bound to the polling loop (see Run).
+	watcherWG sync.WaitGroup
+
 	// gwReloadPath / gwReloadInterval configure hot reload of
 	// model_gateways / global_inference_gateway. Zero interval disables it.
 	gwReloadPath     string
@@ -170,7 +174,15 @@ func (p *Processor) Run(ctx context.Context, onReady func()) error {
 	// Start the model gateway config watcher (no-op unless reload is enabled).
 	// Must run after initConcurrencyControls so the routing snapshot exists
 	// and makeGuard is available for reload-created endpoint limiters.
-	p.startModelGatewayWatcher(ctx)
+	// The watcher is bound to pollingCtx (not the job-base ctx): once the
+	// processor stops accepting work — guard shutdown or SIGTERM — the route
+	// plane must stop mutating too. Cancel first, then wait for the watcher
+	// to exit so Run returning guarantees no config swap is still in flight.
+	p.startModelGatewayWatcher(pollingCtx)
+	defer func() {
+		stopAccepting()
+		p.watcherWG.Wait()
+	}()
 
 	// If async inference is used (llm-d-async), set up a registry of ResultBroadcasters.
 	// These will propagate results from the async queues to the JobExecutor's individual result collectors.
@@ -259,6 +271,12 @@ func (p *Processor) initConcurrencyControls(logger logr.Logger, stopAccepting co
 }
 
 // Stop gracefully stops the processor, waiting for all workers to finish.
+// Once workers drain it also closes the currently installed routing
+// snapshot's resolver when that resolver was created by a config reload:
+// Clientset.Close releases only the startup resolver, so without this the
+// last swapped-in resolver's HTTP transports would leak for the rest of the
+// process lifetime. Safe to call when reload never ran (snapshot resolver
+// equals the startup resolver) or when Run was never called.
 func (p *Processor) Stop(ctx context.Context) {
 	logger := logr.FromContextOrDiscard(ctx)
 	done := make(chan struct{})
@@ -273,6 +291,24 @@ func (p *Processor) Stop(ctx context.Context) {
 
 	case <-done: // all workers have finished
 		logger.V(logging.INFO).Info("All workers have finished")
+	}
+
+	p.closeReloadedRouting(logger)
+}
+
+// closeReloadedRouting closes the live routing snapshot's resolver when it
+// is a reload-created resolver (not the startup one owned by the Clientset).
+// Expected callers have already exited the watcher (Run waits for it), so no
+// swap can race this read.
+func (p *Processor) closeReloadedRouting(logger logr.Logger) {
+	s := p.routing.Load()
+	if s == nil || s.resolver == nil || s.resolver == p.inference {
+		return
+	}
+	if err := s.resolver.Close(); err != nil {
+		logger.Error(err, "Failed to close reloaded model gateway clients on shutdown")
+	} else {
+		logger.V(logging.INFO).Info("Closed reloaded model gateway clients on shutdown")
 	}
 }
 

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -247,6 +247,11 @@ func (p *Processor) initConcurrencyControls(logger logr.Logger, stopAccepting co
 	} else {
 		routing.gateways = resolved
 	}
+	if filesHash, hashErr := referencedFilesHash(p.cfg); hashErr != nil {
+		logger.Error(hashErr, "Failed to hash referenced gateway files for reload baseline; a content-only key/cert rotation applied before the first reload may wait for a further config change")
+	} else {
+		routing.referencedFilesHash = &filesHash
+	}
 	p.routing.Store(routing)
 
 	const highCardinalityThreshold = 50

--- a/internal/util/com/secrets.go
+++ b/internal/util/com/secrets.go
@@ -35,6 +35,14 @@ const (
 	SecretKeyS3SecretAccessKey = "s3-secret-access-key"
 )
 
+// SecretFilePath returns the absolute path a key name resolves to under the
+// mounted secrets directory. Callers that need to stat or fingerprint secret
+// contents (e.g. the config reload watcher) use this so the path convention
+// stays in one place.
+func SecretFilePath(filename string) string {
+	return secretsMountPath + "/" + filename
+}
+
 // ReadSecretFile reads a secret value from the mounted secrets directory.
 // filename is the key name only (not a full path); the secrets mount path is prepended internally.
 // Returns an empty string without error if the file does not exist.

--- a/pkg/clients/inference/inference_client_impl.go
+++ b/pkg/clients/inference/inference_client_impl.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/go-logr/logr"
@@ -30,6 +31,10 @@ import (
 
 // Compile-time check: InferenceHTTPClient implements InferenceClient.
 var _ InferenceClient = (*InferenceHTTPClient)(nil)
+
+// Compile-time check: InferenceHTTPClient is closeable. Used by
+// GatewayResolver.Close (e.g. when config reload replaces a resolver).
+var _ io.Closer = (*InferenceHTTPClient)(nil)
 
 // InferenceHTTPClient wraps the generic HTTP client and implements InferenceClient interface
 type InferenceHTTPClient struct {
@@ -43,6 +48,12 @@ func NewInferenceClient(config *HTTPClientConfig, logger logr.Logger) (*Inferenc
 		return nil, err
 	}
 	return &InferenceHTTPClient{client: client}, nil
+}
+
+// Close releases idle connections held by the client. In-flight requests
+// are not interrupted (see httpclient.HTTPClient.Close).
+func (c *InferenceHTTPClient) Close() error {
+	return c.client.Close()
 }
 
 // Generate makes an inference request with automatic retry logic

--- a/pkg/clients/inference/inference_client_resolver.go
+++ b/pkg/clients/inference/inference_client_resolver.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -82,6 +83,9 @@ type GatewayResolver struct {
 	modelClients map[string]InferenceClient
 	clientURLs   map[InferenceClient]string
 	closers      []io.Closer
+
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // NewGlobalResolver creates a GatewayResolver where all models resolve to a
@@ -209,16 +213,25 @@ func (r *GatewayResolver) ClientLabel(c InferenceClient) string {
 	return "unknown"
 }
 
-// Close releases resources held by the resolver (e.g. Redis connections for
-// async dispatch). Safe to call on resolvers that hold no closeable resources.
+// Close releases resources held by the resolver (e.g. HTTP transports).
+// Safe to call on resolvers that hold no closeable resources.
+//
+// Close is idempotent and safe for concurrent use: a resolver can be closed
+// from several places (the swap grace-period timer, processor Stop, tests),
+// and the resolver contract allows arbitrary io.Closer implementations that
+// do not necessarily tolerate double-close. Only the first call closes the
+// underlying resources; every call returns the same error.
 func (r *GatewayResolver) Close() error {
-	var errs []error
-	for _, c := range r.closers {
-		if err := c.Close(); err != nil {
-			errs = append(errs, err)
+	r.closeOnce.Do(func() {
+		var errs []error
+		for _, c := range r.closers {
+			if err := c.Close(); err != nil {
+				errs = append(errs, err)
+			}
 		}
-	}
-	return errors.Join(errs...)
+		r.closeErr = errors.Join(errs...)
+	})
+	return r.closeErr
 }
 
 // NewSingleClientResolver wraps a single InferenceClient in a GatewayResolver

--- a/pkg/clients/inference/inference_client_resolver.go
+++ b/pkg/clients/inference/inference_client_resolver.go
@@ -99,6 +99,13 @@ func NewGlobalResolver(config GatewayClientConfig, logger logr.Logger) (*Gateway
 	}, nil
 }
 
+// newInferenceClient is the client constructor used by NewPerModelResolver.
+// Declared as a var so tests can substitute a failing constructor over
+// closeable fakes when asserting failure-path cleanup.
+var newInferenceClient = func(config *HTTPClientConfig, logger logr.Logger) (InferenceClient, error) {
+	return NewInferenceClient(config, logger)
+}
+
 // NewPerModelResolver creates a GatewayResolver that routes each model to its
 // own inference gateway. Clients with identical settings share a single
 // HTTPClient instance to reuse connection pools.
@@ -112,8 +119,17 @@ func NewPerModelResolver(configs map[string]GatewayClientConfig, logger logr.Log
 			modelClients[model] = client
 			continue
 		}
-		client, err := NewInferenceClient(gw.toHTTPClientConfig(), logger)
+		client, err := newInferenceClient(gw.toHTTPClientConfig(), logger)
 		if err != nil {
+			// Close the clients already built for earlier gateways: the
+			// caller (config reload) retries failed construction every
+			// poll, so leaked HTTP transports would accumulate. Iterating
+			// the pool closes each unique client exactly once.
+			for _, pooled := range pool {
+				if closer, ok := pooled.(io.Closer); ok {
+					_ = closer.Close()
+				}
+			}
 			return nil, fmt.Errorf("failed to create inference client for model %q (url %s): %w", model, gw.URL, err)
 		}
 		pool[gw] = client

--- a/pkg/clients/inference/inference_client_resolver.go
+++ b/pkg/clients/inference/inference_client_resolver.go
@@ -214,6 +214,7 @@ func NewSingleClientResolver(c InferenceClient) *GatewayResolver {
 	return &GatewayResolver{
 		globalClient: c,
 		clientURLs:   map[InferenceClient]string{c: "test"},
+		closers:      asClosers([]InferenceClient{c}),
 	}
 }
 

--- a/pkg/clients/inference/inference_client_resolver.go
+++ b/pkg/clients/inference/inference_client_resolver.go
@@ -73,8 +73,10 @@ const ErrCodeModelNotFound = "model_not_found"
 //  3. Return nil — the caller should treat this as a request-level error.
 //
 // GatewayResolver is immutable after construction — safe for concurrent reads.
-// TODO: When dynamic config reload is added, wrap with atomic.Pointer[GatewayResolver]
-// and swap the entire resolver on reload.
+// Dynamic config reload builds a fresh GatewayResolver and swaps it
+// atomically into the processor's routing state (see
+// internal/processor/worker/config_reload.go); old resolvers are closed
+// after a grace period once they fall out of the routing path.
 type GatewayResolver struct {
 	globalClient InferenceClient
 	modelClients map[string]InferenceClient
@@ -93,6 +95,7 @@ func NewGlobalResolver(config GatewayClientConfig, logger logr.Logger) (*Gateway
 	return &GatewayResolver{
 		globalClient: client,
 		clientURLs:   map[InferenceClient]string{client: config.URL},
+		closers:      asClosers([]InferenceClient{client}),
 	}, nil
 }
 
@@ -118,7 +121,24 @@ func NewPerModelResolver(configs map[string]GatewayClientConfig, logger logr.Log
 		modelClients[model] = client
 	}
 
-	return &GatewayResolver{modelClients: modelClients, clientURLs: urls}, nil
+	closers := make([]InferenceClient, 0, len(pool))
+	for _, client := range pool {
+		closers = append(closers, client)
+	}
+
+	return &GatewayResolver{modelClients: modelClients, clientURLs: urls, closers: asClosers(closers)}, nil
+}
+
+// asClosers returns the io.Closer views of clients that support closing.
+// Mock clients used in tests do not implement io.Closer and are skipped.
+func asClosers(clients []InferenceClient) []io.Closer {
+	closers := make([]io.Closer, 0, len(clients))
+	for _, c := range clients {
+		if closer, ok := c.(io.Closer); ok {
+			closers = append(closers, closer)
+		}
+	}
+	return closers
 }
 
 // IsGlobal returns true if the resolver routes all models to a single global

--- a/pkg/clients/inference/inference_client_resolver_test.go
+++ b/pkg/clients/inference/inference_client_resolver_test.go
@@ -297,3 +297,52 @@ func TestGatewayResolver_ClientLabel(t *testing.T) {
 		}
 	})
 }
+
+func TestResolverClosersWiring(t *testing.T) {
+	perModelCfg := map[string]GatewayClientConfig{
+		// m1 and m2 share identical settings → pooled into one client.
+		"m1": {URL: "http://shared:8000"},
+		"m2": {URL: "http://shared:8000"},
+		"m3": {URL: "http://other:8000"},
+	}
+	perModel, err := NewPerModelResolver(perModelCfg, testLogger(t))
+	if err != nil {
+		t.Fatalf("NewPerModelResolver: %v", err)
+	}
+	// One closeable resource per unique gateway endpoint (per-model clients
+	// are HTTP clients, which implement io.Closer).
+	if got := len(perModel.closers); got != 2 {
+		t.Fatalf("per-model closers = %d, want 2 (one per unique endpoint)", got)
+	}
+	if err := perModel.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	global, err := NewGlobalResolver(GatewayClientConfig{URL: "http://shared:8000"}, testLogger(t))
+	if err != nil {
+		t.Fatalf("NewGlobalResolver: %v", err)
+	}
+	if got := len(global.closers); got != 1 {
+		t.Fatalf("global closers = %d, want 1", got)
+	}
+	if err := global.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Mock-injected resolvers hold no closeables: Close must stay a no-op.
+	mocks := NewPerModelClientResolver(map[string]InferenceClient{
+		"m1": &mockGenerateClient{},
+	})
+	if got := len(mocks.closers); got != 0 {
+		t.Fatalf("mock-client closers = %d, want 0", got)
+	}
+	if err := mocks.Close(); err != nil {
+		t.Fatalf("Close (mocks): %v", err)
+	}
+}
+
+type mockGenerateClient struct{}
+
+func (m *mockGenerateClient) Generate(_ context.Context, _ *GenerateRequest) (*GenerateResponse, *ClientError) {
+	return &GenerateResponse{StatusCode: 200}, nil
+}

--- a/pkg/clients/inference/inference_client_resolver_test.go
+++ b/pkg/clients/inference/inference_client_resolver_test.go
@@ -18,8 +18,10 @@ package inference
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -345,4 +347,52 @@ type mockGenerateClient struct{}
 
 func (m *mockGenerateClient) Generate(_ context.Context, _ *GenerateRequest) (*GenerateResponse, *ClientError) {
 	return &GenerateResponse{StatusCode: 200}, nil
+}
+
+type closableStubClient struct {
+	stubClient
+	closed atomic.Bool
+}
+
+func (c *closableStubClient) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+// TestNewPerModelResolverFailureClosesCreatedClients: when client
+// construction fails partway through the per-model loop, the clients
+// already built for earlier gateways must be closed — a failed reload is
+// retried every poll, so leaked HTTP transports would accumulate. The pool
+// must close each unique client exactly once (models sharing a config hold
+// the same client).
+func TestNewPerModelResolverFailureClosesCreatedClients(t *testing.T) {
+	first := &closableStubClient{stubClient: stubClient{id: "first"}}
+
+	orig := newInferenceClient
+	var calls atomic.Int32
+	newInferenceClient = func(*HTTPClientConfig, logr.Logger) (InferenceClient, error) {
+		if calls.Add(1) == 1 {
+			return first, nil
+		}
+		return nil, errors.New("invalid TLS material")
+	}
+	defer func() { newInferenceClient = orig }()
+
+	// m1 and m2 share identical settings (one pooled client); the other
+	// endpoint triggers the second, failing construction. Map iteration
+	// order is irrelevant: exactly one client is created before the failure.
+	r, err := NewPerModelResolver(map[string]GatewayClientConfig{
+		"m1": {URL: "http://shared:8000"},
+		"m2": {URL: "http://shared:8000"},
+		"m3": {URL: "http://other:8000", APIKey: "k"},
+	}, testLogger(t))
+	if err == nil {
+		t.Fatal("expected NewPerModelResolver to fail when a gateway client cannot be constructed")
+	}
+	if r != nil {
+		t.Fatal("failed construction must not return a resolver")
+	}
+	if !first.closed.Load() {
+		t.Fatal("client created before the failing gateway must be closed")
+	}
 }

--- a/pkg/clients/inference/inference_client_resolver_test.go
+++ b/pkg/clients/inference/inference_client_resolver_test.go
@@ -19,8 +19,10 @@ package inference
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -357,6 +359,57 @@ type closableStubClient struct {
 func (c *closableStubClient) Close() error {
 	c.closed.Store(true)
 	return nil
+}
+
+// countingCloser records how many times Close ran and returns a fixed error.
+type countingCloser struct {
+	calls atomic.Int32
+	err   error
+}
+
+func (c *countingCloser) Close() error {
+	c.calls.Add(1)
+	return c.err
+}
+
+// TestGatewayResolverCloseIdempotent: a resolver can be closed from several
+// places (the swap grace-period timer, processor Stop, tests) and wraps
+// arbitrary io.Closer implementations that need not tolerate double-close.
+// Repeated and concurrent Close calls must run the underlying closers
+// exactly once and return the same error to every caller.
+func TestGatewayResolverCloseIdempotent(t *testing.T) {
+	wantErr := errors.New("close failed")
+	closer := &countingCloser{err: wantErr}
+	r := &GatewayResolver{closers: []io.Closer{closer}}
+
+	const callers = 8
+	errs := make([]error, callers)
+	var wg sync.WaitGroup
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = r.Close()
+		}()
+	}
+	wg.Wait()
+
+	if got := closer.calls.Load(); got != 1 {
+		t.Fatalf("underlying Close ran %d times, want exactly 1", got)
+	}
+	for i, err := range errs {
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("Close (caller %d) = %v, want %v", i, err, wantErr)
+		}
+	}
+
+	// A further sequential Close reuses the cached result.
+	if err := r.Close(); !errors.Is(err, wantErr) {
+		t.Fatalf("subsequent Close = %v, want %v", err, wantErr)
+	}
+	if got := closer.calls.Load(); got != 1 {
+		t.Fatalf("underlying Close ran %d times after a repeat call, want 1", got)
+	}
 }
 
 // TestNewPerModelResolverFailureClosesCreatedClients: when client


### PR DESCRIPTION
## Summary

Implements the long-standing TODO in the inference client resolver ("monitor gateway config for changes"): the processor can now hot-reload `model_gateways` / `global_inference_gateway` from its config file without a rolling restart. The feature is fully opt-in via a new flag `--model-gateway-reload-interval` (default `0` = disabled; when disabled, behavior is byte-identical to today).

1. **Atomic routing snapshot.** The routing plane (gateway resolver + per-endpoint concurrency limiters + inference-objective lookup) is captured in an immutable `routingSnapshot` behind an `atomic.Pointer`. Reload builds a fresh snapshot through the exact same path as startup (`LoadFromYAML` + `Validate` + `ResolveModelGateways`) and swaps it in; every job pins its snapshot at job start, so in-flight jobs never observe a mid-flight routing change.
2. **Polling watcher with content fingerprint.** Stdlib ticker + SHA-256 fingerprint — no new dependencies. The fingerprint covers not just the config file but also the referenced files that actually feed resolution: `api_key_file`, mounted secrets, TLS cert/key, and the global gateway's fallback `inference-api-key` (included unconditionally for the global gateway, since the resolver falls back to it whenever the explicit key source is empty). Rotating a Secret/cert with unchanged config paths therefore reloads routing correctly.
3. **Safe failure semantics.** Any parse/validate/build error keeps the old routing, records a failure metric, and keeps retrying on subsequent ticks (the applied fingerprint only advances on success). A no-op change skips rebuild entirely; unchanged endpoints keep their AIMD limiters (matched by URL), so learned concurrency state survives a swap.
4. **Ownership-safe client lifecycle.** Replaced resolvers are closed after a 30s grace period (idle connections only; in-flight requests are never interrupted). Startup resolver stays owned by the Clientset; reload-created resolvers are owned by the Processor (`Stop()` closes the last one). `GatewayResolver.Close` is idempotent under concurrent callers.
5. **Explicitly not hot-reloadable.** Changing `route_key_method` at runtime is rejected loudly (the resolver keys and request-side route keys must come from the same method); async dispatch mode and structural settings still require a restart. Removed models surface through the existing `model_not_found` path — no new error plumbing.

**Observability:** `batch_processor_model_gateway_reload_total{result=success|failed}` and `batch_processor_model_gateway_reload_last_success_timestamp_seconds`.

## Test plan

- Unit tests cover: watcher loop end-to-end (flip config YAMLs mid-run: add/remove models, move endpoint URL, corrupt file, missing file, recovery), per-job snapshot pinning across preprocess/execute, AIMD carryover, no-op detection, TLS/api-key rotation forcing rebuild, nil baseline hash forcing one rebuild-and-anchor, resolver close ownership (startup vs reloaded), leak-free failure paths, idempotent Close, and reload-metric registration robustness.
- `go build ./...`, `go vet ./...`, `go test ./...` green; `go test -race` green on all touched packages; `gofmt` clean; no dependency changes.
- Live-cluster verification (ConfigMap edit → swap, in-flight drain during the grace window, Prometheus scrape) is planned as a follow-up; flag defaults keep the feature off until then.

Note: `TestExecuteJob_SLOExpiredDuringDispatch` is a known pre-existing race-timing flake on `main` (reproduces on the base commit); unrelated to this change.
