### PR TITLE
fix(processor): isolate async result queues by replica

### DIFF
--- a/benchmarks/setup.sh
+++ b/benchmarks/setup.sh
@@ -624,7 +624,7 @@ EOVLLMSVC
         --set "ap.redis.url=redis://redis-master.${NAMESPACE}.svc.cluster.local:6379" \
         --set ap.redis.pollIntervalMs=500 \
         --set ap.redis.batchSize=10 \
-        --set-json "ap.redis.queuesConfig=[{\"queue_name\":\"llm-d-async:requests:${ASYNC_POOL_NAME}\",\"result_queue_name\":\"llm-d-async:results:${ASYNC_POOL_NAME}\",\"request_path_url\":\"/v1/chat/completions\",\"igw_base_url\":\"${ASYNC_IGW_URL}\",\"gate_type\":\"endpoint-scrape\",\"gate_params\":{\"url\":\"${ASYNC_METRICS_URL}\",\"metric\":\"vllm:num_requests_waiting\",\"max_count_per_pod\":\"5\",\"fallback\":\"1.0\"}}]" \
+        --set-json "ap.redis.queuesConfig=[{\"queue_name\":\"llm-d-async:requests:${ASYNC_POOL_NAME}\",\"request_path_url\":\"/v1/chat/completions\",\"igw_base_url\":\"${ASYNC_IGW_URL}\",\"gate_type\":\"endpoint-scrape\",\"gate_params\":{\"url\":\"${ASYNC_METRICS_URL}\",\"metric\":\"vllm:num_requests_waiting\",\"max_count_per_pod\":\"5\",\"fallback\":\"1.0\"}}]" \
         --set ap.modelServerMonitor.enabled=false \
         --set ap.metrics.enabled=true \
         --set ap.metrics.port=9091 \

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -403,8 +403,9 @@ processor:
     # Async dispatch mode (alternative to sync).
     # Set dispatchMode: "async" and configure asyncDispatch.models instead
     # of modelGateways. Each model maps to a Redis-backed inference pool.
-    # Queue names can be set explicitly; when omitted they are derived from
+    # Queue base names can be set explicitly; when omitted they are derived from
     # inferencePoolName (deprecated — set explicit names for new deployments).
+    # The Processor appends its replica identity to each result queue base name.
     # dispatchMode: "async"
     # asyncDispatch:
     #   resultPollTimeout: "30s"
@@ -413,12 +414,12 @@ processor:
     #       inferencePoolName: "pool-a"
     #       inferenceObjective: "batch-sheddable-a"  # optional: GIE InferenceObjective CRD name
     #       requestQueueName: "llm-d-async:requests:pool-a"  # optional: explicit request queue
-    #       resultQueueName: "llm-d-async:results:pool-a"    # optional: explicit result queue
+    #       resultQueueName: "llm-d-async:results:pool-a"    # optional: explicit result queue base
     #     "mistral":
     #       inferencePoolName: "pool-b"
     #       inferenceObjective: "batch-sheddable-b"
     #       requestQueueName: "llm-d-async:requests:pool-b"
-    #       resultQueueName: "llm-d-async:results:pool-b"
+    #       resultQueueName: "llm-d-async:results:pool-b"    # optional: explicit result queue base
     defaultOutputExpirationSeconds: 7776000  # 90 days
     progressTTLSeconds: 86400  # 24 hours
     # Whether to send x-gateway-inference-fairness-id on inference requests.

--- a/cmd/batch-processor/main.go
+++ b/cmd/batch-processor/main.go
@@ -51,7 +51,10 @@ func main() {
 
 func run() error {
 	// load configuration & logging setup
-	hostname, _ := os.Hostname()
+	hostname, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("get Processor hostname: %w", err)
+	}
 	logger := klog.NewKlogr().WithValues("hostname", hostname, "service", "batch-processor")
 	ctx := logr.NewContext(context.Background(), logger)
 
@@ -108,7 +111,7 @@ func run() error {
 		cfg.TerminateOnObservabilityFailure,
 	)
 
-	procClients, err := buildProcessorClients(ctx, cfg)
+	procClients, err := buildProcessorClients(ctx, cfg, hostname)
 	if err != nil {
 		logger.Error(err, "Failed to build processor clients")
 		return err
@@ -273,7 +276,7 @@ func waitObservabilityFatalError(ctx context.Context, obsFatalCh <-chan error, w
 }
 
 // buildProcessorClients constructs all processor clients using the same backend as the apiserver
-func buildProcessorClients(ctx context.Context, cfg *config.ProcessorConfig) (*clientset.Clientset, error) {
+func buildProcessorClients(ctx context.Context, cfg *config.ProcessorConfig, processorID string) (*clientset.Clientset, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	cfg.DBClientCfg.RedisCfg.ServiceName = "batch-processor"
@@ -297,6 +300,7 @@ func buildProcessorClients(ctx context.Context, cfg *config.ProcessorConfig) (*c
 		opts = append(opts, clientset.WithPerModelInference(resolved.PerModel))
 	}
 	if resolved.Async != nil {
+		resolved.Async.ConsumerID = processorID
 		opts = append(opts, clientset.WithAsyncInference(*resolved.Async))
 	}
 	clients, err := clientset.NewClientset(ctx, ucom.ComponentProcessor, opts...)

--- a/docs/design/batch-dispatcher-queue-design.md
+++ b/docs/design/batch-dispatcher-queue-design.md
@@ -54,13 +54,17 @@ Queue names follow a fixed convention keyed by the inference pool name:
 | Queue | Redis Type | Name Pattern | Example |
 |-------|-----------|--------------|---------|
 | Request queue | Sorted Set | `llm-d-async:requests:{pool_name}` | `llm-d-async:requests:optimized-baseline` |
-| Result queue | List | `llm-d-async:results:{pool_name}` | `llm-d-async:results:optimized-baseline` |
+| Result queue | List | `llm-d-async:results:{pool_name}:{processor_id}` | `llm-d-async:results:optimized-baseline:batch-gateway-processor-7d9f6c8b5f-k2m4n` |
 
-The `pool_name` corresponds to the target [InferencePool](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/). Both queue names are derived from a single `pool_name` — they are always configured as a pair, never independently. Queue names are computed by the batch-processor's async resolver in [`async_inference_client_resolver.go`](https://github.com/llm-d/llm-d-batch-gateway/blob/main/pkg/clients/inference/async_inference_client_resolver.go), as `asyncQueuePrefix + "requests:" + poolName` and `asyncQueuePrefix + "results:" + poolName`.
+The `pool_name` corresponds to the target [InferencePool](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/). The request queue and result queue base name are derived from the pool name. The batch-processor's async resolver appends the Processor hostname to the result queue base name, so replicas share requests but cannot consume one another's results. The resolved names are `asyncQueuePrefix + "requests:" + poolName` and `asyncQueuePrefix + "results:" + poolName + ":" + processorID`.
 
 The prefix `llm-d-async` (`asyncQueuePrefix`) is currently hardcoded but can be made configurable, so that multiple installations can share the same Redis instance without key collisions (e.g., `staging`, `prod`, or an application-specific identifier).
 
-> **Note — the `$batch` / tenant suffix:** the batch-processor derives suffix-less result queue names (`llm-d-async:results:{pool_name}`). The llm-d-async producer treats `ResultQueueName` as the *full* Redis list key and does **not** append anything — so a `{tenant_id}` suffix such as `$batch` (seen in some llm-d-async examples) is purely a naming convention, not something either side adds automatically. Per-tenant isolation (routing results to different queues per user or API key) would require the batch-processor to build the suffix explicitly; it is reserved for future use. Because the names must match on both sides, the dispatcher's `--redis.ss.result-queue-name` must be set to the exact suffix-less name the processor consumes.
+The llm-d-async producer treats `ResultQueueName` as the full Redis list key and carries it on each request. The Async Processor must preserve that per-request destination. When using a `queuesConfig`, leave its per-queue `result_queue_name` unset; llm-d Async versions through v0.9.0 give that static value precedence over the request-provided result queue. A top-level default result queue may still be configured as a fallback.
+
+For an existing deployment, first remove the per-queue `result_queue_name` override and wait for the Async Processor rollout to complete. Only then upgrade the Batch Processors. Upgrading a Batch Processor first strands its results even with a single replica: the Processor listens on its replica-specific queue while the old Async configuration continues writing to the static queue.
+
+Replica-specific queues prevent healthy Processors from stealing results from one another. They do not recover results after the owning Processor is lost; pod-loss recovery and cleanup of abandoned result queues are tracked in [#645](https://github.com/llm-d/llm-d-batch-gateway/issues/645).
 
 When the dispatcher is used, the inference gateway endpoint configuration lives entirely on the dispatcher side: the batch-processor does not need to know about gateway URLs, TLS settings, or routing modes. The batch-processor only needs the pool name, the connector type, and the connector endpoint.
 
@@ -109,7 +113,7 @@ The dispatcher (llm-d-async) already supports the Redis sorted-set flow with dis
 --redis.ss.result-queue-name llm-d-async:results:optimized-baseline
 ```
 
-The queue names must match those derived by the batch-processor's async resolver (`llm-d-async:requests:{pool_name}` / `llm-d-async:results:{pool_name}`).
+The request queue must match the name derived by the batch-processor's async resolver. The result queue shown here is a fallback; each Batch Processor request carries its replica-specific result destination.
 
 The dispatcher pulls up to `max_SYS × budget` requests per poll cycle and forwards them to the inference gateway. See the [llm-d-async README](https://github.com/llm-d/llm-d-async/blob/main/README.md) and [Helm chart values](https://github.com/llm-d/llm-d-async/tree/main/charts/async-processor) for the full configuration.
 
@@ -210,7 +214,7 @@ Result messages follow the format defined in the [llm-d-async README — Results
 
 ### Dispatcher (writes to result queue)
 
-After the dispatcher receives a response from the inference gateway (success or failure), it writes the result to the result queue (e.g., `llm-d-async:results:{pool_name}`). The `metadata` from the original request is carried through so the consumer can route the result.
+After the dispatcher receives a response from the inference gateway (success or failure), it writes the result to the replica-specific result queue carried on the request (e.g., `llm-d-async:results:{pool_name}:{processor_id}`).
 
 ### Consumer (Batch-Processor)
 
@@ -224,7 +228,7 @@ Because a job's pipeline is short-lived but the result queue is long-lived and s
 2. Converts each raw result into a `ResultItem` (preserving the HTTP status, or mapping non-HTTP failures to an error result).
 3. Fans that `ResultItem` out to **every currently-subscribed result channel** — it does not itself filter by job or model.
 
-Broadcasters outlive individual jobs, so a single `GetResult()` consumer per pool keeps draining the queue even as jobs start and finish.
+Broadcasters outlive individual jobs, so a single `GetResult()` consumer per pool and Processor replica keeps draining that replica's result queue even as jobs start and finish.
 
 #### ResultCollector (per-job)
 

--- a/docs/guides/deploy-k8s.md
+++ b/docs/guides/deploy-k8s.md
@@ -1047,6 +1047,8 @@ kubectl rollout status deployment/${PROMETHEUS_NAME} -n ${LLM_NAMESPACE} --timeo
 <details>
 <summary>Deploy async-processor</summary>
 
+> Do not set `result_queue_name` inside `queuesConfig`. Batch Processor replicas provide their own result destinations on each request; a static per-queue value overrides that routing in llm-d Async versions through v0.9.0. When upgrading, remove the per-queue override and wait for the Async Processor rollout to complete before upgrading the Batch Processors. Reversing this order strands results even with one Processor replica.
+
 ```bash
 DISPATCHER_RELEASE=dispatcher
 DISPATCHER_VERSION=${DISPATCHER_VERSION:-v0.7.3}
@@ -1076,7 +1078,6 @@ ap:
     batchSize: 10
     queuesConfig:
       - queue_name: "llm-d-async:requests:${LLMD_POOL_NAME}"
-        result_queue_name: "llm-d-async:results:${LLMD_POOL_NAME}"
         request_path_url: "/v1/chat/completions"
         igw_base_url: "http://${INTERNAL_GW_SVC}.${BATCH_INTERNAL_GATEWAY_NAMESPACE}.svc.cluster.local/${LLM_NAMESPACE}/${MODEL_NAME}"
         gate_type: "prometheus-budget"

--- a/examples/deploy-demo/deploy-k8s.sh
+++ b/examples/deploy-demo/deploy-k8s.sh
@@ -813,7 +813,6 @@ ap:
     batchSize: 10
     queuesConfig:
       - queue_name: "llm-d-async:requests:${LLMD_POOL_NAME}"
-        result_queue_name: "llm-d-async:results:${LLMD_POOL_NAME}"
         request_path_url: "/v1/chat/completions"
         igw_base_url: "${igw_base_url}"
         gate_type: "prometheus-budget"

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -109,11 +109,11 @@ type AsyncModelConfig struct {
 	// a future release. Set explicit queue names for new deployments.
 	RequestQueueName string `yaml:"request_queue_name"`
 
-	// ResultQueueName overrides the Redis sorted-set queue name used to
-	// read inference results. When empty, the name is derived from
-	// InferencePoolName as "llm-d-async:results:<pool>".
+	// ResultQueueName overrides the Redis list base name used to read inference
+	// results. The Processor appends its replica identity. When empty, the base
+	// name is derived from InferencePoolName as "llm-d-async:results:<pool>".
 	// Deprecated fallback: the derived naming convention will be removed in
-	// a future release. Set explicit queue names for new deployments.
+	// a future release. Set an explicit queue base name for new deployments.
 	ResultQueueName string `yaml:"result_queue_name"`
 }
 

--- a/pkg/clients/inference/async_inference_client_resolver.go
+++ b/pkg/clients/inference/async_inference_client_resolver.go
@@ -41,6 +41,7 @@ type AsyncModelPoolConfig struct {
 // AsyncClientConfig holds the resolved configuration for async dispatch.
 type AsyncClientConfig struct {
 	RedisURL          string
+	ConsumerID        string // identity of this Batch Processor replica
 	Models            map[string]AsyncModelPoolConfig
 	ResultPollTimeout time.Duration // per-poll timeout in the result dispatcher loop
 }
@@ -72,8 +73,8 @@ func (r *AsyncGatewayResolver) Models() []string {
 }
 
 // SharedClientFor returns a shared client for the given model.
-// Reuses the same client across calls — results are not routed
-// per-request, any consumer can read them.
+// Reuses the same client across calls. Results for this Processor replica are
+// isolated on its consumer-specific result queue.
 func (r *AsyncGatewayResolver) SharedClientFor(modelID string) AsyncInferenceClient {
 	if r.clientFactories != nil {
 		if factory, ok := r.clientFactories[modelID]; ok {
@@ -113,6 +114,10 @@ func (r *AsyncGatewayResolver) Close() error {
 // NewAsyncResolver creates an AsyncGatewayResolver with one shared pool
 // (producer) per model/pool pair.
 func NewAsyncResolver(config AsyncClientConfig, logger logr.Logger) (*AsyncGatewayResolver, error) {
+	if config.ConsumerID == "" {
+		return nil, fmt.Errorf("consumerID must not be empty")
+	}
+
 	opts, err := redis.ParseURL(config.RedisURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse async inference Redis URL: %w", err)
@@ -147,6 +152,9 @@ func NewAsyncResolver(config AsyncClientConfig, logger logr.Logger) (*AsyncGatew
 		if resQueue == "" {
 			resQueue = asyncQueuePrefix + "results:" + mcfg.PoolName
 		}
+		// Each Processor consumes from its own result queue so another healthy
+		// replica cannot consume and discard its results.
+		resQueue = resQueue + ":" + config.ConsumerID
 
 		p, err := producer.NewRedisSortedSetProducer(
 			producer.RedisSortedSetConfig{

--- a/pkg/clients/inference/async_inference_client_resolver.go
+++ b/pkg/clients/inference/async_inference_client_resolver.go
@@ -155,6 +155,12 @@ func NewAsyncResolver(config AsyncClientConfig, logger logr.Logger) (*AsyncGatew
 		// Each Processor consumes from its own result queue so another healthy
 		// replica cannot consume and discard its results.
 		resQueue = resQueue + ":" + config.ConsumerID
+		logger.Info(
+			"Configured async inference queues",
+			"model", model,
+			"requestQueue", reqQueue,
+			"resultQueue", resQueue,
+		)
 
 		p, err := producer.NewRedisSortedSetProducer(
 			producer.RedisSortedSetConfig{

--- a/pkg/clients/inference/async_inference_client_resolver_test.go
+++ b/pkg/clients/inference/async_inference_client_resolver_test.go
@@ -17,18 +17,24 @@ limitations under the License.
 package inference
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	asyncapi "github.com/llm-d/llm-d-async/api"
 )
+
+const testAsyncConsumerID = "processor-0"
 
 func TestNewAsyncResolver(t *testing.T) {
 	t.Run("creates per-model clients", func(t *testing.T) {
 		mr := miniredis.RunT(t)
 
 		cfg := AsyncClientConfig{
-			RedisURL: "redis://" + mr.Addr(),
+			RedisURL:   "redis://" + mr.Addr(),
+			ConsumerID: testAsyncConsumerID,
 			Models: map[string]AsyncModelPoolConfig{
 				"model-a": {PoolName: "pool-a"},
 				"model-b": {PoolName: "pool-b"},
@@ -56,7 +62,8 @@ func TestNewAsyncResolver(t *testing.T) {
 		mr := miniredis.RunT(t)
 
 		r, err := NewAsyncResolver(AsyncClientConfig{
-			RedisURL: "redis://" + mr.Addr(),
+			RedisURL:   "redis://" + mr.Addr(),
+			ConsumerID: testAsyncConsumerID,
 			Models: map[string]AsyncModelPoolConfig{
 				"model-a": {PoolName: "pool-a"},
 			},
@@ -75,7 +82,8 @@ func TestNewAsyncResolver(t *testing.T) {
 		mr := miniredis.RunT(t)
 
 		_, err := NewAsyncResolver(AsyncClientConfig{
-			RedisURL: "redis://" + mr.Addr(),
+			RedisURL:   "redis://" + mr.Addr(),
+			ConsumerID: testAsyncConsumerID,
 			Models: map[string]AsyncModelPoolConfig{
 				"model-a": {PoolName: "shared-pool"},
 				"model-b": {PoolName: "shared-pool"},
@@ -89,7 +97,8 @@ func TestNewAsyncResolver(t *testing.T) {
 
 	t.Run("invalid Redis URL returns error", func(t *testing.T) {
 		_, err := NewAsyncResolver(AsyncClientConfig{
-			RedisURL: "not-a-url",
+			RedisURL:   "not-a-url",
+			ConsumerID: testAsyncConsumerID,
 			Models: map[string]AsyncModelPoolConfig{
 				"model-a": {PoolName: "pool-a"},
 			},
@@ -100,11 +109,26 @@ func TestNewAsyncResolver(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects empty consumer ID", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		_, err := NewAsyncResolver(AsyncClientConfig{
+			RedisURL: "redis://" + mr.Addr(),
+			Models: map[string]AsyncModelPoolConfig{
+				"model-a": {PoolName: "pool-a"},
+			},
+			ResultPollTimeout: time.Second,
+		}, testLogger(t))
+		if err == nil {
+			t.Fatal("expected error for empty consumer ID")
+		}
+	})
+
 	t.Run("close releases resources", func(t *testing.T) {
 		mr := miniredis.RunT(t)
 
 		r, err := NewAsyncResolver(AsyncClientConfig{
-			RedisURL: "redis://" + mr.Addr(),
+			RedisURL:   "redis://" + mr.Addr(),
+			ConsumerID: testAsyncConsumerID,
 			Models: map[string]AsyncModelPoolConfig{
 				"model-a": {PoolName: "pool-a"},
 			},
@@ -123,7 +147,8 @@ func TestNewAsyncResolver(t *testing.T) {
 		mr := miniredis.RunT(t)
 
 		r, err := NewAsyncResolver(AsyncClientConfig{
-			RedisURL: "redis://" + mr.Addr(),
+			RedisURL:   "redis://" + mr.Addr(),
+			ConsumerID: testAsyncConsumerID,
 			Models: map[string]AsyncModelPoolConfig{
 				"model-a": {PoolName: "pool-a"},
 			},
@@ -137,6 +162,109 @@ func TestNewAsyncResolver(t *testing.T) {
 		client2 := r.SharedClientFor("model-a")
 		if client1 != client2 {
 			t.Fatal("expected same client from SharedClientFor")
+		}
+	})
+
+	t.Run("isolates results by consumer while sharing requests", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		const (
+			requestQueue = "llm-d-async:requests:shared-pool"
+			resultQueue  = "llm-d-async:results:shared-pool"
+		)
+
+		newResolver := func(consumerID string) *AsyncGatewayResolver {
+			r, err := NewAsyncResolver(AsyncClientConfig{
+				RedisURL:   "redis://" + mr.Addr(),
+				ConsumerID: consumerID,
+				Models: map[string]AsyncModelPoolConfig{
+					"model-a": {
+						PoolName:         "shared-pool",
+						RequestQueueName: requestQueue,
+						ResultQueueName:  resultQueue,
+					},
+				},
+				ResultPollTimeout: time.Second,
+			}, testLogger(t))
+			if err != nil {
+				t.Fatalf("NewAsyncResolver(%q): %v", consumerID, err)
+			}
+			t.Cleanup(func() { _ = r.Close() })
+			return r
+		}
+
+		resolverA := newResolver("processor-a")
+		resolverB := newResolver("processor-b")
+		clientA := resolverA.SharedClientFor("model-a")
+		clientB := resolverB.SharedClientFor("model-a")
+
+		for _, submission := range []struct {
+			client    AsyncInferenceClient
+			requestID string
+		}{
+			{client: clientA, requestID: "request-a"},
+			{client: clientB, requestID: "request-b"},
+		} {
+			if submitErr := submission.client.Submit(context.Background(), &GenerateRequest{
+				RequestID: submission.requestID,
+				Endpoint:  "/v1/chat/completions",
+				Params:    map[string]any{"model": "model-a"},
+			}); submitErr != nil {
+				t.Fatalf("Submit(%q): %s", submission.requestID, submitErr.Message)
+			}
+		}
+
+		members, err := mr.ZMembers(requestQueue)
+		if err != nil {
+			t.Fatalf("ZMembers(%q): %v", requestQueue, err)
+		}
+		if len(members) != 2 {
+			t.Fatalf("shared request queue contains %d requests, want 2", len(members))
+		}
+
+		routes := make(map[string]string, len(members))
+		for _, member := range members {
+			var request asyncapi.InternalRequest
+			if err := json.Unmarshal([]byte(member), &request); err != nil {
+				t.Fatalf("unmarshal request: %v", err)
+			}
+			routes[request.PublicRequest.ReqID()] = request.ResultQueueName
+		}
+
+		queueA := resultQueue + ":processor-a"
+		queueB := resultQueue + ":processor-b"
+		if got := routes["request-a"]; got != queueA {
+			t.Fatalf("request-a result queue = %q, want %q", got, queueA)
+		}
+		if got := routes["request-b"]; got != queueB {
+			t.Fatalf("request-b result queue = %q, want %q", got, queueB)
+		}
+
+		pushResult := func(queue, requestID string) {
+			payload, err := json.Marshal(asyncapi.ResultMessage{ID: requestID, Payload: `{"ok":true}`})
+			if err != nil {
+				t.Fatalf("marshal result: %v", err)
+			}
+			if _, err := mr.Lpush(queue, string(payload)); err != nil {
+				t.Fatalf("LPUSH(%q): %v", queue, err)
+			}
+		}
+		pushResult(queueB, "request-b")
+		pushResult(queueA, "request-a")
+
+		resultA, err := clientA.GetResult(context.Background())
+		if err != nil {
+			t.Fatalf("consumer A GetResult: %v", err)
+		}
+		if resultA.RequestID != "request-a" {
+			t.Fatalf("consumer A received %q, want request-a", resultA.RequestID)
+		}
+
+		resultB, err := clientB.GetResult(context.Background())
+		if err != nil {
+			t.Fatalf("consumer B GetResult: %v", err)
+		}
+		if resultB.RequestID != "request-b" {
+			t.Fatalf("consumer B received %q, want request-b", resultB.RequestID)
 		}
 	})
 }

--- a/test/e2e/dispatcher/helm-values-prometheus.yaml
+++ b/test/e2e/dispatcher/helm-values-prometheus.yaml
@@ -21,7 +21,6 @@ ap:
     batchSize: 10
     queuesConfig:
       - queue_name: "llm-d-async:requests:sim-pool-prom"
-        result_queue_name: "llm-d-async:results:sim-pool-prom"
         request_path_url: "/v1/completions"
         igw_base_url: "http://vllm-sim.default.svc.cluster.local:8000"
         gate_type: "prometheus-query"

--- a/test/e2e/dispatcher/helm-values-scrape.yaml
+++ b/test/e2e/dispatcher/helm-values-scrape.yaml
@@ -20,7 +20,6 @@ ap:
     batchSize: 10
     queuesConfig:
       - queue_name: "llm-d-async:requests:sim-pool-scrape"
-        result_queue_name: "llm-d-async:results:sim-pool-scrape"
         request_path_url: "/v1/completions"
         igw_base_url: "http://vllm-sim.default.svc.cluster.local:8000"
         gate_type: "endpoint-scrape"

--- a/test/e2e/dispatcher/helm-values.yaml
+++ b/test/e2e/dispatcher/helm-values.yaml
@@ -20,14 +20,12 @@ ap:
     batchSize: 10
     queuesConfig:
       - queue_name: "llm-d-async:requests:sim-pool"
-        result_queue_name: "llm-d-async:results:sim-pool"
         request_path_url: "/v1/completions"
         igw_base_url: "http://vllm-sim.default.svc.cluster.local:8000"
         gate_type: "redis"
         gate_params:
           address: "redis-master.default.svc.cluster.local:6379"
       - queue_name: "llm-d-async:requests:sim-pool-gate"
-        result_queue_name: "llm-d-async:results:sim-pool-gate"
         request_path_url: "/v1/completions"
         igw_base_url: "http://vllm-sim.default.svc.cluster.local:8000"
         gate_type: "redis"

--- a/test/e2e/dispatcher_test.go
+++ b/test/e2e/dispatcher_test.go
@@ -422,8 +422,13 @@ func testDispatcherMultiReplicaBatch(t *testing.T) {
 		batchIDs = append(batchIDs, mustCreateBatch(t, fileID))
 	}
 
+	completionDeadline := time.Now().Add(3 * time.Minute)
 	for _, batchID := range batchIDs {
-		batch, results := waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusCompleted)
+		remaining := time.Until(completionDeadline)
+		if remaining <= 0 {
+			t.Fatalf("batches did not complete within the shared timeout")
+		}
+		batch, results := waitForBatchStatus(t, batchID, remaining, openai.BatchStatusCompleted)
 
 		if batch.RequestCounts.Total != requestsPerBatch {
 			t.Errorf("batch %s: total requests = %d, want %d", batchID, batch.RequestCounts.Total, requestsPerBatch)

--- a/test/e2e/dispatcher_test.go
+++ b/test/e2e/dispatcher_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -88,25 +89,21 @@ func newDispatcherProducer(t *testing.T, rdb *redis.Client, poolName string) *pr
 	return p
 }
 
-// detectDispatcherDeployed checks whether at least one async-processor
-// deployment exists in the test namespace.
+// detectDispatcherDeployed checks whether at least one llm-d Async deployment
+// exists in the test namespace.
 func detectDispatcherDeployed(t *testing.T) bool {
 	t.Helper()
 
 	out, err := exec.Command("kubectl", "get", "deployments",
 		"-n", testNamespace,
+		"-l", "app.kubernetes.io/name in (async-processor,llm-d-async)",
 		"-o", "name",
 	).CombinedOutput()
 	if err != nil {
 		t.Logf("kubectl get deployments failed: %v", err)
 		return false
 	}
-	for _, line := range strings.Split(string(out), "\n") {
-		if strings.Contains(line, "async-processor") {
-			return true
-		}
-	}
-	return false
+	return strings.TrimSpace(string(out)) != ""
 }
 
 func TestDispatcher(t *testing.T) {
@@ -138,6 +135,9 @@ func TestDispatcher(t *testing.T) {
 	})
 	t.Run("MultiRequestBatch", func(t *testing.T) {
 		testDispatcherMultiRequestBatch(t, rdb)
+	})
+	t.Run("MultiReplicaBatch", func(t *testing.T) {
+		testDispatcherMultiReplicaBatch(t)
 	})
 	t.Run("HTTPErrorStatusPreserved", func(t *testing.T) {
 		testDispatcherHTTPErrorStatusPreserved(t, rdb)
@@ -176,7 +176,8 @@ func testDispatcherHTTPErrorStatusPreserved(t *testing.T, rdb *redis.Client) {
 	batchID := mustCreateBatch(t, fileID)
 	t.Logf("Created batch %s; waiting for request in %s", batchID, injectReqQueue)
 
-	reqID := waitAndStealQueuedRequestID(t, rdb, injectReqQueue, 30*time.Second)
+	reqID, resultQueue := waitAndStealQueuedRequest(t, rdb, injectReqQueue, 30*time.Second)
+	defer rdb.Del(ctx, resultQueue)
 	t.Logf("Got request %s; injecting StatusCode=403 result", reqID)
 
 	resultBytes, err := json.Marshal(asyncapi.ResultMessage{
@@ -187,7 +188,7 @@ func testDispatcherHTTPErrorStatusPreserved(t *testing.T, rdb *redis.Client) {
 	if err != nil {
 		t.Fatalf("marshal ResultMessage: %v", err)
 	}
-	if err := rdb.LPush(ctx, injectResultQueue, string(resultBytes)).Err(); err != nil {
+	if err := rdb.LPush(ctx, resultQueue, string(resultBytes)).Err(); err != nil {
 		t.Fatalf("LPUSH result: %v", err)
 	}
 
@@ -239,9 +240,10 @@ func testDispatcherHTTPErrorStatusPreserved(t *testing.T, rdb *redis.Client) {
 	t.Logf("Batch %s preserved HTTP 403 in output (no parse_error)", batchID)
 }
 
-// waitAndStealQueuedRequestID waits until a request appears in the Redis sorted
-// set queue, removes it, and returns the request ID from the InternalRequest envelope.
-func waitAndStealQueuedRequestID(t *testing.T, rdb *redis.Client, queue string, timeout time.Duration) string {
+// waitAndStealQueuedRequest waits until a request appears in the Redis sorted
+// set queue, removes it, and returns its request ID and result queue from the
+// InternalRequest envelope.
+func waitAndStealQueuedRequest(t *testing.T, rdb *redis.Client, queue string, timeout time.Duration) (string, string) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -277,10 +279,13 @@ func waitAndStealQueuedRequestID(t *testing.T, rdb *redis.Client, queue string, 
 		if reqID == "" {
 			t.Fatalf("empty request ID in queued message: %s", member)
 		}
-		return reqID
+		if ir.ResultQueueName == "" {
+			t.Fatalf("empty result queue in queued message: %s", member)
+		}
+		return reqID, ir.ResultQueueName
 	}
 	t.Fatalf("no request appeared in %s within %v", queue, timeout)
-	return ""
+	return "", ""
 }
 
 func testDispatcherBatchRoundTrip(t *testing.T, rdb *redis.Client) {
@@ -337,6 +342,106 @@ func testDispatcherMultiRequestBatch(t *testing.T, rdb *redis.Client) {
 	}
 
 	t.Logf("All 3 requests completed via dispatcher")
+}
+
+// testDispatcherMultiReplicaBatch verifies that two healthy Batch Processor
+// replicas do not consume and discard one another's async results.
+func testDispatcherMultiReplicaBatch(t *testing.T) {
+	selector := fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=processor", testHelmRelease)
+	var workloads []string
+	var discoveryErrors []string
+	for _, kind := range []string{"deployment", "statefulset"} {
+		out, err := exec.Command("kubectl", "get", kind,
+			"-n", testNamespace,
+			"-l", selector,
+			"-o", `jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}`,
+		).CombinedOutput()
+		if err != nil {
+			discoveryErrors = append(discoveryErrors, fmt.Sprintf("%s: %v: %s", kind, err, strings.TrimSpace(string(out))))
+			continue
+		}
+		for _, name := range strings.Fields(string(out)) {
+			workloads = append(workloads, kind+"/"+name)
+		}
+	}
+	if len(workloads) != 1 {
+		t.Fatalf("find one Processor workload with selector %q: found %v; discovery errors: %v", selector, workloads, discoveryErrors)
+	}
+	workload := workloads[0]
+	replicasOut, err := exec.Command("kubectl", "get", workload,
+		"-n", testNamespace, "-o", "jsonpath={.spec.replicas}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("get Processor replica count for %s: %v\n%s", workload, err, replicasOut)
+	}
+	originalReplicas, err := strconv.Atoi(strings.TrimSpace(string(replicasOut)))
+	if err != nil {
+		t.Fatalf("parse Processor replica count %q: %v", replicasOut, err)
+	}
+
+	scaleProcessor := func(replicas int) error {
+		out, scaleErr := exec.Command("kubectl", "scale", workload,
+			"-n", testNamespace, fmt.Sprintf("--replicas=%d", replicas)).CombinedOutput()
+		if scaleErr != nil {
+			return fmt.Errorf("scale Processor to %d replicas: %w\n%s", replicas, scaleErr, out)
+		}
+		out, scaleErr = exec.Command("kubectl", "rollout", "status", workload,
+			"-n", testNamespace, "--timeout=180s").CombinedOutput()
+		if scaleErr != nil {
+			return fmt.Errorf("wait for %d Processor replicas: %w\n%s", replicas, scaleErr, out)
+		}
+		return nil
+	}
+
+	if originalReplicas != 2 {
+		t.Cleanup(func() {
+			if err := scaleProcessor(originalReplicas); err != nil {
+				t.Errorf("cleanup: %v", err)
+			}
+		})
+		if err := scaleProcessor(2); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const (
+		batchCount       = 2
+		requestsPerBatch = 32
+	)
+	batchIDs := make([]string, 0, batchCount)
+	for batchIndex := 0; batchIndex < batchCount; batchIndex++ {
+		lines := make([]string, 0, requestsPerBatch)
+		for requestIndex := 0; requestIndex < requestsPerBatch; requestIndex++ {
+			lines = append(lines, fmt.Sprintf(
+				`{"custom_id":"multi-replica-%d-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"batch %d request %d"}]}}`,
+				batchIndex, requestIndex, testModel, batchIndex, requestIndex))
+		}
+
+		fileID := mustCreateFile(t,
+			fmt.Sprintf("dispatcher-multi-replica-%d-%s.jsonl", batchIndex, testRunID),
+			strings.Join(lines, "\n"))
+		batchIDs = append(batchIDs, mustCreateBatch(t, fileID))
+	}
+
+	for _, batchID := range batchIDs {
+		batch, results := waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusCompleted)
+
+		if batch.RequestCounts.Total != requestsPerBatch {
+			t.Errorf("batch %s: total requests = %d, want %d", batchID, batch.RequestCounts.Total, requestsPerBatch)
+		}
+		if batch.RequestCounts.Completed != requestsPerBatch {
+			t.Errorf("batch %s: completed requests = %d, want %d", batchID, batch.RequestCounts.Completed, requestsPerBatch)
+		}
+		if batch.RequestCounts.Failed != 0 {
+			t.Errorf("batch %s: failed requests = %d, want 0", batchID, batch.RequestCounts.Failed)
+		}
+		if results == nil {
+			t.Fatalf("batch %s: expected non-nil results", batchID)
+		}
+		if results.OutputLines != requestsPerBatch {
+			t.Errorf("batch %s: output lines = %d, want %d", batchID, results.OutputLines, requestsPerBatch)
+		}
+		validateBatchResults(t, batch, *results)
+	}
 }
 
 func testDispatcherRedisGate(t *testing.T, rdb *redis.Client) {


### PR DESCRIPTION
## Why is this PR needed?

Each Batch Processor currently calls `BRPOP` on the same result list. A result can therefore be consumed by a replica that does not own the job. That replica rejects the unknown request ID after Redis has already removed the result, leaving the owning job stuck.

llm-d Async already carries the producer's `ResultQueueName` on each request and routes the result back to it. This change uses that existing contract: Processors still submit to the same request queue, but each Processor listens on `<result_queue_base>:<processor_id>`.

This fixes result stealing between healthy replicas. Recovery after the owning Processor is lost remains separate durability work in #645. This change does not depend on #582; if that ownership design is adopted later, it must preserve the per-Processor result-routing contract or replace it with equivalent durable routing.

When llm-d Async is configured with `queuesConfig`, its per-queue `result_queue_name` must be omitted because current Async releases give that static value precedence over the per-request result destination. A top-level result queue may remain configured as a fallback. For upgrades, remove the per-queue override and wait for the Async rollout before upgrading Batch Processors; reversing that order strands results even with one Processor replica. The repository's E2E, benchmark, demo, and deployment-guide configurations are updated accordingly.

## What does this PR do?

- Keep each pool's Async request queue shared across Batch Processor replicas.
- Derive a replica-specific result queue from the configured result queue base and the Processor ID.
- Add a Redis contract test proving that two Processors share requests while receiving only their own results.
- Add a two-replica E2E that submits two 32-request jobs and verifies that every input produces exactly one successful output.
- Update the Async deployment guidance to preserve the per-request result destination.

## How was this tested?

- `go test ./...`
- `go test -tags=integration ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test -race ./pkg/clients/inference`
- Replica-isolation contract test repeated 100 times
- `goimports` clean; `go mod tidy -diff` clean
- `gosec` introduced no findings relative to current `main`
- Linux/amd64 Batch Processor build
- E2E module compile and vet
- Helm lint for default and all CI values, template render, and 100 Helm unit tests
- Patch applies cleanly to current `main`
- Live Kubernetes E2E against a real Batch Gateway API, shared storage and Redis, llm-d Async (`1f8c876`), and NVIDIA Dynamo frontend/router (`Qwen/Qwen3-0.6B`): label-based discovery resolved the custom workload name `batch-repro-644-batch-gateway-processor`, and two patched replicas on separate nodes completed two concurrent 32-request jobs with 64/64 unique successful outputs, zero failed requests, and zero duplicate or missing results

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

Closes #644
