### PR TITLE
fix(otel): support OTEL_TRACES_EXPORTER=none|otlp|console in InitTracer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.71.0
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.45.0
 	go.opentelemetry.io/otel/sdk v1.46.0
 	go.opentelemetry.io/otel/trace v1.46.0
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 h1:OFnwLJr+pF3iHrlGSzb
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0/go.mod h1:716wFneO0ov19A2beH5hjfh9AK5z/VWNAtDijp1Y0/g=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0 h1:w53CDeOA/Kurp7yRsegSr6pbbr759dOvJ+yNmWM6Hxs=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0/go.mod h1:BOmGMCbAtvcJiSJ+hLuhgPLdDbimnraSl8irz3iY8sY=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.45.0 h1:lsA/S1bxgdbyFGkTj+3meEdJ6ADVU7QoFstV6MXgE68=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.45.0/go.mod h1:L7u+MirGoB1bjeLH66+xDykF4RC8C3RN7lIFpBiewUo=
 go.opentelemetry.io/otel/metric v1.46.0 h1:yBnkXvgV7AXFILZc5K6IZe/CBFF3OS7BJ8ov6/lj0K8=
 go.opentelemetry.io/otel/metric v1.46.0/go.mod h1:iPmdWqifKUdzziPkvvzIJXITl56fQx2mGM/DHLB3/2o=
 go.opentelemetry.io/otel/sdk v1.46.0 h1:h5CNQQjEbuQXY/JfZtgt3i7HVFV3aHPO2OAwO2eTYPI=

--- a/internal/util/otel/init_tracer_test.go
+++ b/internal/util/otel/init_tracer_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otel
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+func TestTraceExporterType(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		set  bool
+		want string
+	}{
+		{name: "unset defaults to otlp", set: false, want: exporterTypeOTLP},
+		{name: "otlp", env: "otlp", set: true, want: exporterTypeOTLP},
+		{name: "console", env: "console", set: true, want: exporterTypeConsole},
+		{name: "none", env: "none", set: true, want: exporterTypeNone},
+		{name: "an unrecognised value falls back to otlp", env: "jaeger", set: true, want: exporterTypeOTLP},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("OTEL_TRACES_EXPORTER", tc.env)
+			}
+
+			got := traceExporterType(context.Background())
+			if got != tc.want {
+				t.Errorf("traceExporterType() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// newSpanExporter must build exactly the exporter it was asked for. The stdout
+// exporter in particular must not be constructed for the otlp type.
+func TestNewSpanExporter(t *testing.T) {
+	tests := []struct {
+		exporterType string
+		wantType     string
+	}{
+		{exporterType: exporterTypeOTLP, wantType: "*otlptrace.Exporter"},
+		{exporterType: exporterTypeConsole, wantType: "*stdouttrace.Exporter"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.exporterType, func(t *testing.T) {
+			exporter, err := newSpanExporter(context.Background(), tc.exporterType)
+			if err != nil {
+				t.Fatalf("newSpanExporter(%q) error = %v", tc.exporterType, err)
+			}
+			t.Cleanup(func() {
+				if err := exporter.Shutdown(context.Background()); err != nil {
+					t.Errorf("exporter.Shutdown() error = %v", err)
+				}
+			})
+
+			if got := fmt.Sprintf("%T", exporter); got != tc.wantType {
+				t.Errorf("newSpanExporter(%q) = %s, want %s", tc.exporterType, got, tc.wantType)
+			}
+		})
+	}
+}
+
+// "none" must still install the propagator and produce a usable, sampled span,
+// it just must not register an exporter.
+func TestInitTracerNoneStillCreatesSpans(t *testing.T) {
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+
+	origTP, origProp := otel.GetTracerProvider(), otel.GetTextMapPropagator()
+	t.Cleanup(func() {
+		otel.SetTracerProvider(origTP)
+		otel.SetTextMapPropagator(origProp)
+	})
+
+	shutdown, err := InitTracer(context.Background())
+	if err != nil {
+		t.Fatalf("InitTracer() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown() error = %v", err)
+		}
+	})
+
+	if _, ok := otel.GetTextMapPropagator().(propagation.TraceContext); !ok {
+		t.Errorf("propagator = %T, want propagation.TraceContext to still be installed", otel.GetTextMapPropagator())
+	}
+
+	_, span := StartSpan(context.Background(), "none-exporter-span")
+	defer span.End()
+
+	if !span.SpanContext().IsValid() {
+		t.Error("span context is not valid, want spans to still be created and propagated")
+	}
+}

--- a/internal/util/otel/otel.go
+++ b/internal/util/otel/otel.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -33,6 +34,15 @@ import (
 )
 
 const defaultServiceName = "batch-gateway"
+
+// The exporter types OTEL_TRACES_EXPORTER selects between.
+const (
+	exporterTypeOTLP    = "otlp"
+	exporterTypeConsole = "console"
+	exporterTypeNone    = "none"
+
+	defaultExporterType = exporterTypeOTLP
+)
 
 // Span attribute keys for batch-gateway resources.
 const (
@@ -106,27 +116,23 @@ func DetachedContext(ctx context.Context, name string) (context.Context, trace.S
 	return StartSpan(bgCtx, name, trace.WithLinks(links...))
 }
 
-// InitTracer sets up an OpenTelemetry TracerProvider with an OTLP gRPC exporter.
-// It reads the endpoint from the OTEL_EXPORTER_OTLP_ENDPOINT environment variable.
-// If the endpoint is not set, tracing is disabled (no-op) and a nil shutdown function is returned.
-// The service name defaults to "batch-gateway" and can be overridden via OTEL_SERVICE_NAME.
+// InitTracer sets up an OpenTelemetry TracerProvider.
+// Configuration is done via environment variables:
+// - OTEL_TRACES_EXPORTER: Span exporter, "otlp", "console" or "none" (default: otlp)
+// - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP collector endpoint, consumed by the otlp exporter
+// - OTEL_SERVICE_NAME: Service name (default: "batch-gateway")
+//
+// The propagator is installed unconditionally, before the exporter type is resolved, so
+// trace context received by this process is still forwarded downstream even when
+// OTEL_TRACES_EXPORTER=none.
 func InitTracer(ctx context.Context) (shutdown func(context.Context) error, err error) {
-	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-	if endpoint == "" {
-		logr.FromContextOrDiscard(ctx).Info("OTEL_EXPORTER_OTLP_ENDPOINT not set, tracing disabled")
-		return func(context.Context) error { return nil }, nil
-	}
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	exporterType := traceExporterType(ctx)
 
 	serviceName := os.Getenv("OTEL_SERVICE_NAME")
 	if serviceName == "" {
 		serviceName = defaultServiceName
-	}
-
-	// The OTLP exporter respects standard OTel env vars (OTEL_EXPORTER_OTLP_ENDPOINT,
-	// OTEL_EXPORTER_OTLP_INSECURE, etc.) automatically.
-	exporter, err := otlptracegrpc.New(ctx)
-	if err != nil {
-		return nil, err
 	}
 
 	res, err := resource.New(ctx,
@@ -136,14 +142,63 @@ func InitTracer(ctx context.Context) (shutdown func(context.Context) error, err 
 		return nil, err
 	}
 
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter),
+	opt := []sdktrace.TracerProviderOption{
 		sdktrace.WithResource(res),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.TraceContext{})
+	}
 
-	logr.FromContextOrDiscard(ctx).Info("OpenTelemetry tracing initialized", "endpoint", endpoint, "service", serviceName)
+	// "none" registers no span processor at all. Spans are still created and
+	// propagated, so instrumented code and context propagation are unaffected.
+	if exporterType != exporterTypeNone {
+		exporter, err := newSpanExporter(ctx, exporterType)
+		if err != nil {
+			return nil, err
+		}
+		opt = append(opt, sdktrace.WithBatcher(exporter))
+	}
+
+	tp := sdktrace.NewTracerProvider(opt...)
+	otel.SetTracerProvider(tp)
+
+	logr.FromContextOrDiscard(ctx).Info("OpenTelemetry tracing initialized",
+		"exporter", exporterType,
+		"service", serviceName,
+		"endpoint", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
 
 	return tp.Shutdown, nil
+}
+
+// traceExporterType resolves OTEL_TRACES_EXPORTER to one of the types
+// newSpanExporter builds:
+//
+//   - otlp: export spans through gRPC to an opentelemetry collector
+//   - console: pretty print spans on stdout, for development
+//   - none: create spans but export nothing
+//
+// An unrecognised value falls back to otlp with a logged warning rather than
+// failing startup.
+func traceExporterType(ctx context.Context) string {
+	exporterType := os.Getenv("OTEL_TRACES_EXPORTER")
+	if exporterType == "" {
+		return defaultExporterType
+	}
+
+	switch exporterType {
+	case exporterTypeOTLP, exporterTypeConsole, exporterTypeNone:
+		return exporterType
+	default:
+		logr.FromContextOrDiscard(ctx).Info("unsupported OTEL_TRACES_EXPORTER, falling back to otlp", "value", exporterType)
+		return defaultExporterType
+	}
+}
+
+// newSpanExporter builds the exporter named by exporterType, which traceExporterType
+// has already narrowed to otlp or console; "none" is handled by the caller and never
+// reaches here. The otlp exporter respects the standard OTel env vars
+// (OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_INSECURE, etc.) automatically.
+func newSpanExporter(ctx context.Context, exporterType string) (sdktrace.SpanExporter, error) {
+	if exporterType == exporterTypeConsole {
+		return stdouttrace.New(stdouttrace.WithPrettyPrint())
+	}
+
+	return otlptracegrpc.New(ctx)
 }


### PR DESCRIPTION
## Why is this PR needed?

InitTracer only supported an implicit on/off switch based on whether OTEL_EXPORTER_OTLP_ENDPOINT was set, with otlp as the only exporter. There was no way to select a console exporter for local development, and worse, when tracing was "off" (no endpoint configured) the function returned before installing the W3C trace-context propagator at all, so a request passing through batch-gateway with tracing disabled would drop its incoming trace context entirely instead of forwarding it downstream. 

## What does this PR do?

The propagator is now installed unconditionally at the top of InitTracer, before the exporter type is even resolved, so trace context received by apiserver, batch-processor, and batch-gc is always forwarded regardless of export configuration.

traceExporterType resolves the new OTEL_TRACES_EXPORTER variable against otlp/console/none, defaulting to otlp when unset (matching llm-d-router, llm-d-kv-cache, and llm-d-inference-payload-processor) and falling back to otlp with a logged warning on an unrecognised value instead of failing startup. 

Note the default changed: previously, tracing was off unless OTEL_EXPORTER_OTLP_ENDPOINT was explicitly set. Now, all three binaries default to attempting an otlp export to the SDK's default endpoint (localhost:4317) unless OTEL_TRACES_EXPORTER=none is set. This matches the other three llm-d repos' current default.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
