### PR TITLE
feat: support configurable batch endpoints

### DIFF
--- a/charts/batch-gateway/README.md
+++ b/charts/batch-gateway/README.md
@@ -88,6 +88,14 @@ global:
 
 The chart renders this list into both the API server and processor configurations. Each value must be an absolute path beginning with exactly one slash and cannot contain a host, query string, fragment, or escaped path. Invalid values cause startup validation to fail.
 
+For a rolling upgrade, enable new endpoints on processors before API servers can accept batches that use them:
+
+1. Set `processor.config.extraEndpoints` and wait for the processor rollout to complete.
+2. Set `global.extraEndpoints`, which enables the endpoints for the API server as well.
+3. Reset `processor.config.extraEndpoints` to `null` so it inherits the global value.
+
+Both `processor.config.extraEndpoints` and `apiserver.config.batchAPI.extraEndpoints` default to `null`, meaning they inherit `global.extraEndpoints`. Setting either override to a list replaces the global value for that component; an explicit `[]` disables configured extensions for that component.
+
 The endpoint remains batch-scoped: every request URL in the input JSONL must exactly match the endpoint declared when creating the batch. The configured path is forwarded unchanged in synchronous and asynchronous dispatch modes. Omitting `global.extraEndpoints` preserves the default OpenAI-only behavior.
 
 ## Usage

--- a/charts/batch-gateway/README.md
+++ b/charts/batch-gateway/README.md
@@ -72,7 +72,23 @@ helm upgrade my-release ./charts/batch-gateway \
 ```
 
 ## Configuration
+
 For a complete list of parameters, see [values.yaml](./values.yaml).
+
+### Additional inference endpoints
+
+Batch Gateway accepts the standard OpenAI Batch API endpoints by default. To use an endpoint supplied by an OpenAI-compatible backend, add it explicitly to the shared allowlist:
+
+```yaml
+global:
+  extraEndpoints:
+    - /v1/classify
+    - /v1/pooling
+```
+
+The chart renders this list into both the API server and processor configurations. Each value must be an absolute path beginning with exactly one slash and cannot contain a host, query string, fragment, or escaped path. Invalid values cause startup validation to fail.
+
+The endpoint remains batch-scoped: every request URL in the input JSONL must exactly match the endpoint declared when creating the batch. The configured path is forwarded unchanged in synchronous and asynchronous dispatch modes. Omitting `global.extraEndpoints` preserves the default OpenAI-only behavior.
 
 ## Usage
 

--- a/charts/batch-gateway/templates/apiserver-configmap.yaml
+++ b/charts/batch-gateway/templates/apiserver-configmap.yaml
@@ -60,9 +60,13 @@ data:
         - {{ . | quote }}
         {{- end }}
       {{- end }}
-      {{- if .Values.global.extraEndpoints }}
+      {{- $extraEndpoints := .Values.global.extraEndpoints }}
+      {{- if ne .Values.apiserver.config.batchAPI.extraEndpoints nil }}
+      {{- $extraEndpoints = .Values.apiserver.config.batchAPI.extraEndpoints }}
+      {{- end }}
+      {{- if $extraEndpoints }}
       extra_endpoints:
-        {{- range .Values.global.extraEndpoints }}
+        {{- range $extraEndpoints }}
         - {{ . | quote }}
         {{- end }}
       {{- end }}

--- a/charts/batch-gateway/templates/apiserver-configmap.yaml
+++ b/charts/batch-gateway/templates/apiserver-configmap.yaml
@@ -60,6 +60,12 @@ data:
         - {{ . | quote }}
         {{- end }}
       {{- end }}
+      {{- if .Values.global.extraEndpoints }}
+      extra_endpoints:
+        {{- range .Values.global.extraEndpoints }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
     file_api:
       default_expiration_seconds: {{ .Values.apiserver.config.fileAPI.defaultExpirationSeconds }}
       max_size_bytes: {{ .Values.apiserver.config.fileAPI.maxSizeBytes }}

--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -13,6 +13,12 @@ data:
     task_wait_time: {{ .Values.processor.config.taskWaitTime | quote }}
     poll_interval: {{ .Values.processor.config.pollInterval | quote }}
     num_workers: {{ .Values.processor.config.numWorkers }}
+    {{- if .Values.global.extraEndpoints }}
+    extra_endpoints:
+      {{- range .Values.global.extraEndpoints }}
+      - {{ . | quote }}
+      {{- end }}
+    {{- end }}
     concurrency:
       global: {{ .Values.processor.config.concurrency.global }}
       per_endpoint: {{ .Values.processor.config.concurrency.perEndpoint }}

--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -13,9 +13,13 @@ data:
     task_wait_time: {{ .Values.processor.config.taskWaitTime | quote }}
     poll_interval: {{ .Values.processor.config.pollInterval | quote }}
     num_workers: {{ .Values.processor.config.numWorkers }}
-    {{- if .Values.global.extraEndpoints }}
+    {{- $extraEndpoints := .Values.global.extraEndpoints }}
+    {{- if ne .Values.processor.config.extraEndpoints nil }}
+    {{- $extraEndpoints = .Values.processor.config.extraEndpoints }}
+    {{- end }}
+    {{- if $extraEndpoints }}
     extra_endpoints:
-      {{- range .Values.global.extraEndpoints }}
+      {{- range $extraEndpoints }}
       - {{ . | quote }}
       {{- end }}
     {{- end }}

--- a/charts/batch-gateway/tests/apiserver-configmap_test.yaml
+++ b/charts/batch-gateway/tests/apiserver-configmap_test.yaml
@@ -109,6 +109,22 @@ tests:
           path: data["config.yaml"]
           pattern: 'enable_tls: false'
 
+  - it: should render shared extra endpoints
+    set:
+      global.extraEndpoints:
+        - /v1/classify
+        - /v1/pooling
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'extra_endpoints:\n\s+- "/v1/classify"\n\s+- "/v1/pooling"'
+
+  - it: should omit extra endpoints by default
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "extra_endpoints:"
+
   - it: should not render ConfigMap when apiserver is disabled
     set:
       apiserver.enabled: false

--- a/charts/batch-gateway/tests/apiserver-configmap_test.yaml
+++ b/charts/batch-gateway/tests/apiserver-configmap_test.yaml
@@ -119,6 +119,30 @@ tests:
           path: data["config.yaml"]
           pattern: 'extra_endpoints:\n\s+- "/v1/classify"\n\s+- "/v1/pooling"'
 
+  - it: should prefer API server extra endpoints over the global value
+    set:
+      global.extraEndpoints:
+        - /v1/global
+      apiserver.config.batchAPI.extraEndpoints:
+        - /v1/apiserver
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'extra_endpoints:\n\s+- "/v1/apiserver"'
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: '/v1/global'
+
+  - it: should allow API server extra endpoints to explicitly override global with empty
+    set:
+      global.extraEndpoints:
+        - /v1/global
+      apiserver.config.batchAPI.extraEndpoints: []
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "extra_endpoints:"
+
   - it: should omit extra endpoints by default
     asserts:
       - notMatchRegex:

--- a/charts/batch-gateway/tests/processor-configmap_test.yaml
+++ b/charts/batch-gateway/tests/processor-configmap_test.yaml
@@ -23,6 +23,30 @@ tests:
           path: data["config.yaml"]
           pattern: 'extra_endpoints:\n\s+- "/v1/classify"\n\s+- "/v1/pooling"'
 
+  - it: should prefer processor extra endpoints over the global value
+    set:
+      global.extraEndpoints:
+        - /v1/global
+      processor.config.extraEndpoints:
+        - /v1/processor
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'extra_endpoints:\n\s+- "/v1/processor"'
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: '/v1/global'
+
+  - it: should allow processor extra endpoints to explicitly override global with empty
+    set:
+      global.extraEndpoints:
+        - /v1/global
+      processor.config.extraEndpoints: []
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "extra_endpoints:"
+
   - it: should omit extra endpoints by default
     asserts:
       - notMatchRegex:

--- a/charts/batch-gateway/tests/processor-configmap_test.yaml
+++ b/charts/batch-gateway/tests/processor-configmap_test.yaml
@@ -13,6 +13,22 @@ tests:
           path: data["config.yaml"]
           pattern: 'model_gateways:'
 
+  - it: should render shared extra endpoints
+    set:
+      global.extraEndpoints:
+        - /v1/classify
+        - /v1/pooling
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'extra_endpoints:\n\s+- "/v1/classify"\n\s+- "/v1/pooling"'
+
+  - it: should omit extra endpoints by default
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "extra_endpoints:"
+
   - it: should default tls_insecure_skip_verify to false when omitted from global_inference_gateway
     set:
       processor.config.globalInferenceGateway:

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -2,6 +2,10 @@
 global:
   imagePullSecrets: []
 
+  # Additional inference API paths accepted by both the API server and processor.
+  # Standard OpenAI Batch API endpoints are always allowed.
+  extraEndpoints: []
+
   # Shared pod security context for all components.
   # All three components (apiserver, processor, gc) must run with the same UID/GID
   # when sharing files on a PVC. Per-component overrides are possible via

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -3,7 +3,10 @@ global:
   imagePullSecrets: []
 
   # Additional inference API paths accepted by both the API server and processor.
-  # Standard OpenAI Batch API endpoints are always allowed.
+  # Standard OpenAI Batch API endpoints are always allowed. Component-specific
+  # values override this default and can be used for a processor-first rollout:
+  # first set processor.config.extraEndpoints, wait for the processor rollout,
+  # then set this value, and finally reset the processor override to null.
   extraEndpoints: []
 
   # Shared pod security context for all components.
@@ -203,6 +206,8 @@ apiserver:
       eventTTLSeconds: 2592000
       passThroughHeaders:
         - Authorization
+      # null inherits global.extraEndpoints. A list, including [], overrides it.
+      extraEndpoints: null
     fileAPI:
       defaultExpirationSeconds: 7776000
       maxSizeBytes: 209715200
@@ -314,6 +319,10 @@ processor:
     taskWaitTime: "1s"
     pollInterval: "5s"
     numWorkers: 20
+    # null inherits global.extraEndpoints. Set this first for a processor-first
+    # rollout, then reset it to null after global.extraEndpoints is enabled.
+    # An explicit [] disables extensions for this component.
+    extraEndpoints: null
     concurrency:
       # Fixed ceiling for total in-flight requests across all endpoints.
       # When AIMD is enabled, per-endpoint limits self-regulate via backpressure,

--- a/cmd/apiserver/config.yaml
+++ b/cmd/apiserver/config.yaml
@@ -78,6 +78,11 @@ batch_api:
   # pass_through_headers:
   #   - "X-MaaS-Username"
   #   - "X-MaaS-Group"
+  # Additional deployment-specific inference paths. Standard OpenAI endpoints
+  # are always allowed. Configure the identical list on the processor.
+  # extra_endpoints:
+  #   - "/v1/classify"
+  #   - "/v1/pooling"
 
 # File API configuration
 file_api:

--- a/cmd/batch-processor/config.yaml
+++ b/cmd/batch-processor/config.yaml
@@ -2,6 +2,12 @@
 task_wait_time: "1s"
 poll_interval: "5s"
 num_workers: 20
+
+# Additional deployment-specific inference paths. Standard OpenAI endpoints
+# are always allowed. This list must match batch_api.extra_endpoints on the API server.
+# extra_endpoints:
+#   - "/v1/classify"
+#   - "/v1/pooling"
 queue_time_bucket:
   start: 0.1
   factor: 2

--- a/internal/apiserver/batch/batch_handler.go
+++ b/internal/apiserver/batch/batch_handler.go
@@ -51,18 +51,16 @@ type BatchAPIHandler struct {
 	endpointAllowlist openai.EndpointAllowlist
 }
 
-func NewBatchAPIHandler(config *common.ServerConfig, clients *clientset.Clientset) *BatchAPIHandler {
+func NewBatchAPIHandler(config *common.ServerConfig, clients *clientset.Clientset) (*BatchAPIHandler, error) {
 	endpointAllowlist, err := openai.NewEndpointAllowlist(config.BatchAPI.ExtraEndpoints)
 	if err != nil {
-		// ServerConfig.Validate rejects this at startup. Fail closed if a caller
-		// constructs an unvalidated config directly.
-		endpointAllowlist = openai.EndpointAllowlist{}
+		return nil, fmt.Errorf("extra endpoints: %w", err)
 	}
 	return &BatchAPIHandler{
 		config:            config,
 		clients:           clients,
 		endpointAllowlist: endpointAllowlist,
-	}
+	}, nil
 }
 
 func (c *BatchAPIHandler) GetRoutes() []common.Route {

--- a/internal/apiserver/batch/batch_handler.go
+++ b/internal/apiserver/batch/batch_handler.go
@@ -46,14 +46,22 @@ import (
 var _ common.ApiHandler = (*BatchAPIHandler)(nil)
 
 type BatchAPIHandler struct {
-	config  *common.ServerConfig
-	clients *clientset.Clientset
+	config            *common.ServerConfig
+	clients           *clientset.Clientset
+	endpointAllowlist openai.EndpointAllowlist
 }
 
 func NewBatchAPIHandler(config *common.ServerConfig, clients *clientset.Clientset) *BatchAPIHandler {
+	endpointAllowlist, err := openai.NewEndpointAllowlist(config.BatchAPI.ExtraEndpoints)
+	if err != nil {
+		// ServerConfig.Validate rejects this at startup. Fail closed if a caller
+		// constructs an unvalidated config directly.
+		endpointAllowlist = openai.EndpointAllowlist{}
+	}
 	return &BatchAPIHandler{
-		config:  config,
-		clients: clients,
+		config:            config,
+		clients:           clients,
+		endpointAllowlist: endpointAllowlist,
 	}
 }
 
@@ -102,7 +110,7 @@ func (c *BatchAPIHandler) CreateBatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// validate request
-	if err := batchReq.Validate(); err != nil {
+	if err := batchReq.ValidateWithEndpointAllowlist(c.endpointAllowlist); err != nil {
 		logger.Error(err, "failed to validate request")
 		apiErr := openai.NewAPIError(http.StatusBadRequest, "", err.Error(), nil)
 		common.WriteAPIError(w, r, apiErr)

--- a/internal/apiserver/batch/batch_handler_test.go
+++ b/internal/apiserver/batch/batch_handler_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -176,6 +177,36 @@ func TestBatchHandler(t *testing.T) {
 						}
 					}
 				})
+			}
+		})
+
+		t.Run("ConfiguredEndpoint", func(t *testing.T) {
+			handler := setupTestHandlerWithConfig(&common.ServerConfig{
+				BatchAPI: common.BatchAPIConfig{ExtraEndpoints: []string{"/v1/classify"}},
+			})
+			const fileID = "file-classify"
+			if err := handler.clients.FileDB.DBStore(context.Background(), &dbapi.FileItem{
+				BaseIndexes: dbapi.BaseIndexes{ID: fileID, TenantID: common.DefaultTenantID},
+				Purpose:     string(openai.FileObjectPurposeBatch),
+			}); err != nil {
+				t.Fatalf("failed to store file: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/batches", strings.NewReader(
+				`{"input_file_id":"file-classify","endpoint":"/v1/classify","completion_window":"24h"}`,
+			))
+			rr := httptest.NewRecorder()
+			handler.CreateBatch(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("CreateBatch() status = %d, want %d; body: %s", rr.Code, http.StatusOK, rr.Body.String())
+			}
+			var batch openai.Batch
+			if err := json.NewDecoder(rr.Body).Decode(&batch); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if batch.Endpoint != "/v1/classify" {
+				t.Errorf("Endpoint = %q, want /v1/classify", batch.Endpoint)
 			}
 		})
 

--- a/internal/apiserver/batch/batch_handler_test.go
+++ b/internal/apiserver/batch/batch_handler_test.go
@@ -67,8 +67,27 @@ func setupTestHandlerWithConfig(config *common.ServerConfig) *BatchAPIHandler {
 		Event:  mockapi.NewMockBatchEventChannelClient(),
 		Status: mockapi.NewMockBatchStatusClient(),
 	}
-	handler := NewBatchAPIHandler(config, clients)
+	handler, err := NewBatchAPIHandler(config, clients)
+	if err != nil {
+		panic(fmt.Sprintf("NewBatchAPIHandler() with valid test config: %v", err))
+	}
 	return handler
+}
+
+func TestNewBatchAPIHandler_InvalidExtraEndpoint(t *testing.T) {
+	config := &common.ServerConfig{
+		BatchAPI: common.BatchAPIConfig{ExtraEndpoints: []string{"/v1/classify?mode=test"}},
+	}
+	handler, err := NewBatchAPIHandler(config, &clientset.Clientset{})
+	if err == nil {
+		t.Fatal("NewBatchAPIHandler() expected error for invalid extra endpoint")
+	}
+	if handler != nil {
+		t.Fatal("NewBatchAPIHandler() returned a handler with invalid configuration")
+	}
+	if !strings.Contains(err.Error(), "extra endpoints") {
+		t.Fatalf("NewBatchAPIHandler() error = %q, want extra endpoints context", err)
+	}
 }
 
 func TestBatchHandler(t *testing.T) {
@@ -1068,7 +1087,10 @@ func TestBatchHandler(t *testing.T) {
 				Event:  failingEvent,
 				Status: mockapi.NewMockBatchStatusClient(),
 			}
-			handler := NewBatchAPIHandler(&common.ServerConfig{}, clients)
+			handler, err := NewBatchAPIHandler(&common.ServerConfig{}, clients)
+			if err != nil {
+				t.Fatalf("NewBatchAPIHandler(): %v", err)
+			}
 
 			batchID := "batch-test-cancel-event-fail"
 			batch := openai.Batch{
@@ -1174,7 +1196,10 @@ func TestBatchHandler(t *testing.T) {
 				Event:  failingEvent,
 				Status: mockapi.NewMockBatchStatusClient(),
 			}
-			handler := NewBatchAPIHandler(&common.ServerConfig{}, clients)
+			handler, err := NewBatchAPIHandler(&common.ServerConfig{}, clients)
+			if err != nil {
+				t.Fatalf("NewBatchAPIHandler(): %v", err)
+			}
 
 			batchID := "batch-test-cancel-retry-event-fail"
 			cancellingAt := int64(1700000001)

--- a/internal/apiserver/common/config.go
+++ b/internal/apiserver/common/config.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	sharedcfg "github.com/llm-d/llm-d-batch-gateway/internal/shared/config"
+	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
 )
@@ -62,6 +63,7 @@ const (
 type BatchAPIConfig struct {
 	BatchEventTTLSeconds int      `yaml:"batch_event_ttl_seconds"`
 	PassThroughHeaders   []string `yaml:"pass_through_headers"`
+	ExtraEndpoints       []string `yaml:"extra_endpoints"`
 }
 
 func (b *BatchAPIConfig) applyDefaults() {
@@ -195,6 +197,9 @@ func (c *ServerConfig) Validate() error {
 
 	if err := c.FileClientCfg.Retry.Validate(); err != nil {
 		return fmt.Errorf("file_client.retry: %w", err)
+	}
+	if _, err := openai.NewEndpointAllowlist(c.BatchAPI.ExtraEndpoints); err != nil {
+		return fmt.Errorf("batch_api.extra_endpoints: %w", err)
 	}
 
 	return nil

--- a/internal/apiserver/common/config_test.go
+++ b/internal/apiserver/common/config_test.go
@@ -20,7 +20,11 @@ package common
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestAPIServerConfig(t *testing.T) {
@@ -203,6 +207,38 @@ file_client:
 			}
 		})
 
+	})
+}
+
+func TestBatchAPIExtraEndpoints(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		cfg := ServerConfig{Port: "8080", BatchAPI: BatchAPIConfig{ExtraEndpoints: []string{"/v1/classify", "/v1/pooling"}}}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		cfg := ServerConfig{Port: "8080", BatchAPI: BatchAPIConfig{ExtraEndpoints: []string{"/v1/classify?mode=test"}}}
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("Validate() expected error")
+		}
+		if !strings.Contains(err.Error(), "batch_api.extra_endpoints") {
+			t.Errorf("Validate() error = %q, want configuration field context", err)
+		}
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		var cfg ServerConfig
+		err := yaml.Unmarshal([]byte("batch_api:\n  extra_endpoints:\n    - /v1/classify\n    - /v1/pooling\n"), &cfg)
+		if err != nil {
+			t.Fatalf("yaml.Unmarshal() unexpected error: %v", err)
+		}
+		want := []string{"/v1/classify", "/v1/pooling"}
+		if !reflect.DeepEqual(cfg.BatchAPI.ExtraEndpoints, want) {
+			t.Errorf("ExtraEndpoints = %v, want %v", cfg.BatchAPI.ExtraEndpoints, want)
+		}
 	})
 }
 

--- a/internal/apiserver/server/server.go
+++ b/internal/apiserver/server/server.go
@@ -89,7 +89,10 @@ func New(ctx context.Context, config *common.ServerConfig) (*Server, error) {
 	//   Unmatched: Client → ServeMux → Recovery → RequestMiddleware → SecurityHeaders → NotFoundHandler
 	apiMux := http.NewServeMux()
 	fileHandler := file.NewFileAPIHandler(config, clients)
-	batchHandler := batch.NewBatchAPIHandler(config, clients)
+	batchHandler, err := batch.NewBatchAPIHandler(config, clients)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create batch API handler: %w", err)
+	}
 	apiMiddlewares := []common.RouteMiddleware{
 		middleware.Recovery,                     // outermost: catches panics from all inner layers
 		middleware.NewRequestMiddleware(config), // request ID, tenant, logging, metrics, OTel tracing

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	sharedcfg "github.com/llm-d/llm-d-batch-gateway/internal/shared/config"
+	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
 	ucom "github.com/llm-d/llm-d-batch-gateway/internal/util/com"
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/ptr"
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/retry"
@@ -135,6 +136,9 @@ type AsyncDispatchConfig struct {
 }
 
 type ProcessorConfig struct {
+	// ExtraEndpoints adds deployment-specific inference paths to the default OpenAI endpoint allowlist.
+	ExtraEndpoints []string `yaml:"extra_endpoints"`
+
 	// TaskWaitTime is the timeout parameter used when dequeueing from the priority queue
 	// This should be shorter than PollInterval
 	TaskWaitTime time.Duration `yaml:"task_wait_time"`
@@ -422,6 +426,9 @@ func (c *ProcessorConfig) Validate() error {
 
 	if err := c.FileClientCfg.Retry.Validate(); err != nil {
 		return fmt.Errorf("file_client.retry: %w", err)
+	}
+	if _, err := openai.NewEndpointAllowlist(c.ExtraEndpoints); err != nil {
+		return fmt.Errorf("extra_endpoints: %w", err)
 	}
 
 	if c.ProgressTTLSeconds <= 0 {

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -108,6 +108,20 @@ func TestNewConfig_Defaults(t *testing.T) {
 	}
 }
 
+func TestProcessorConfig_Validate_ExtraEndpoints(t *testing.T) {
+	c := NewConfig()
+	c.ModelGateways = validPerModelConfig()
+	c.ExtraEndpoints = []string{"/v1/classify", "/v1/pooling"}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+
+	c.ExtraEndpoints = []string{"/v1/classify?mode=test"}
+	if err := c.Validate(); err == nil {
+		t.Fatal("Validate() expected error for invalid extra endpoint")
+	}
+}
+
 func TestProcessorConfig_Validate_WorkDirEmpty(t *testing.T) {
 	c := NewConfig()
 	c.ModelGateways = validPerModelConfig()

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -166,7 +166,7 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 			return fmt.Errorf("write line %d to input file %q: %w", lineCount, localInputFilePath, err)
 		}
 
-		requestMeta, err := extractAndValidateLine(line)
+		requestMeta, err := extractAndValidateLine(line, p.endpointAllowlist, jobInfo.BatchJob.Endpoint.String())
 		if err != nil {
 			return fmt.Errorf("validate request at line %d: %w", lineCount, err)
 		}
@@ -282,7 +282,7 @@ type requestMeta struct {
 
 // extractAndValidateLine parses and validates a request line and returns the
 // metadata needed during ingestion.
-func extractAndValidateLine(line []byte) (requestMeta, error) {
+func extractAndValidateLine(line []byte, endpointAllowlist openai.EndpointAllowlist, batchEndpoint string) (requestMeta, error) {
 	var req planRequestLine
 	trimmedLine := bytes.TrimSuffix(line, []byte{'\n'})
 	if err := json.Unmarshal(trimmedLine, &req); err != nil {
@@ -303,8 +303,11 @@ func extractAndValidateLine(line []byte) (requestMeta, error) {
 	if !strings.HasPrefix(req.URL, "/") || strings.HasPrefix(req.URL, "//") || strings.Contains(req.URL, "://") {
 		return requestMeta{}, fmt.Errorf("url must be a relative path: %s", req.URL)
 	}
-	if !openai.IsValidEndpoint(req.URL) {
+	if !endpointAllowlist.IsValid(req.URL) {
 		return requestMeta{}, fmt.Errorf("invalid endpoint: %s", req.URL)
+	}
+	if batchEndpoint != "" && req.URL != batchEndpoint {
+		return requestMeta{}, fmt.Errorf("request endpoint %q does not match batch endpoint %q", req.URL, batchEndpoint)
 	}
 	if req.Body.Model == "" {
 		return requestMeta{}, fmt.Errorf("model id is empty")

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -306,7 +306,7 @@ func extractAndValidateLine(line []byte, endpointAllowlist openai.EndpointAllowl
 	if !endpointAllowlist.IsValid(req.URL) {
 		return requestMeta{}, fmt.Errorf("invalid endpoint: %s", req.URL)
 	}
-	if batchEndpoint != "" && req.URL != batchEndpoint {
+	if req.URL != batchEndpoint {
 		return requestMeta{}, fmt.Errorf("request endpoint %q does not match batch endpoint %q", req.URL, batchEndpoint)
 	}
 	if req.Body.Model == "" {

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -95,6 +95,7 @@ func TestPreProcess_BuildsPlansAndModelMap_OffsetsCorrect(t *testing.T) {
 			ID: jobID,
 			BatchSpec: openai.BatchSpec{
 				InputFileID: inputFileID,
+				Endpoint:    openai.EndpointChatCompletions,
 			},
 			BatchStatusInfo: openai.BatchStatusInfo{
 				Status: openai.BatchStatusInProgress,
@@ -244,6 +245,7 @@ func TestPreProcess_SystemPrompts_PrefixHashAndSortOrder(t *testing.T) {
 			ID: jobID,
 			BatchSpec: openai.BatchSpec{
 				InputFileID: inputFileID,
+				Endpoint:    openai.EndpointChatCompletions,
 			},
 			BatchStatusInfo: openai.BatchStatusInfo{
 				Status: openai.BatchStatusInProgress,
@@ -466,6 +468,7 @@ func TestPreProcess_CancelFlag_ReturnsErrCancelled(t *testing.T) {
 			ID: jobID,
 			BatchSpec: openai.BatchSpec{
 				InputFileID: inputFileID,
+				Endpoint:    openai.EndpointChatCompletions,
 			},
 			BatchStatusInfo: openai.BatchStatusInfo{
 				Status: openai.BatchStatusInProgress,
@@ -567,6 +570,7 @@ func TestPreProcess_CancelBeforeSIGTERM_ReturnsErrCancelled(t *testing.T) {
 			ID: jobID,
 			BatchSpec: openai.BatchSpec{
 				InputFileID: inputFileID,
+				Endpoint:    openai.EndpointChatCompletions,
 			},
 			BatchStatusInfo: openai.BatchStatusInfo{
 				Status: openai.BatchStatusInProgress,
@@ -641,6 +645,7 @@ func TestPreProcess_SLOExpiredDuringIngestion_ReturnsErrExpired(t *testing.T) {
 			ID: jobID,
 			BatchSpec: openai.BatchSpec{
 				InputFileID: inputFileID,
+				Endpoint:    openai.EndpointChatCompletions,
 			},
 			BatchStatusInfo: openai.BatchStatusInfo{
 				Status: openai.BatchStatusInProgress,
@@ -1207,7 +1212,7 @@ func TestRunPollingLoop_GuardReEnqueueFails_FallsBackToHandleFailed(t *testing.T
 
 func TestExtractAndValidateLine_StreamTrue_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err == nil {
 		t.Fatal("expected error for stream: true, got nil")
 	}
@@ -1218,7 +1223,7 @@ func TestExtractAndValidateLine_StreamTrue_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_StreamFalse_OK(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","stream":false,"messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	meta, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	meta, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err != nil {
 		t.Fatalf("unexpected error for stream: false: %v", err)
 	}
@@ -1232,7 +1237,7 @@ func TestExtractAndValidateLine_StreamFalse_OK(t *testing.T) {
 
 func TestExtractAndValidateLine_StreamOmitted_OK(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	meta, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	meta, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err != nil {
 		t.Fatalf("unexpected error when stream is omitted: %v", err)
 	}
@@ -1243,7 +1248,7 @@ func TestExtractAndValidateLine_StreamOmitted_OK(t *testing.T) {
 
 func TestExtractAndValidateLine_EmptyCustomID_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err == nil {
 		t.Fatal("expected error for empty custom_id, got nil")
 	}
@@ -1254,7 +1259,7 @@ func TestExtractAndValidateLine_EmptyCustomID_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_MissingCustomID_ReturnsError(t *testing.T) {
 	line := []byte(`{"method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err == nil {
 		t.Fatal("expected error for missing custom_id, got nil")
 	}
@@ -1265,7 +1270,7 @@ func TestExtractAndValidateLine_MissingCustomID_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_MissingMethod_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err == nil {
 		t.Fatal("expected error for missing method, got nil")
 	}
@@ -1276,7 +1281,7 @@ func TestExtractAndValidateLine_MissingMethod_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_InvalidMethod_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"DELETE","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err == nil {
 		t.Fatal("expected error for invalid method, got nil")
 	}
@@ -1287,7 +1292,7 @@ func TestExtractAndValidateLine_InvalidMethod_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_MissingURL_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err == nil {
 		t.Fatal("expected error for missing url, got nil")
 	}
@@ -1298,7 +1303,7 @@ func TestExtractAndValidateLine_MissingURL_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_AbsoluteURL_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"http://evil.com","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err == nil {
 		t.Fatal("expected error for absolute url, got nil")
 	}
@@ -1309,7 +1314,7 @@ func TestExtractAndValidateLine_AbsoluteURL_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_DoubleSlashURL_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"//evil.com","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err == nil {
 		t.Fatal("expected error for protocol-relative url, got nil")
 	}
@@ -1320,7 +1325,7 @@ func TestExtractAndValidateLine_DoubleSlashURL_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_NotAllowedEndpoint_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"/not-allowed","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err == nil {
 		t.Fatal("expected error for invalid endpoint, got nil")
 	}
@@ -1334,6 +1339,17 @@ func TestExtractAndValidateLine_BatchEndpointMismatch(t *testing.T) {
 	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err == nil {
 		t.Fatal("expected error when request endpoint differs from batch endpoint")
+	}
+	if !strings.Contains(err.Error(), "does not match batch endpoint") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestExtractAndValidateLine_EmptyBatchEndpoint(t *testing.T) {
+	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4"}}` + "\n")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	if err == nil {
+		t.Fatal("expected error when stored batch endpoint is empty")
 	}
 	if !strings.Contains(err.Error(), "does not match batch endpoint") {
 		t.Fatalf("unexpected error message: %v", err)
@@ -1364,7 +1380,7 @@ func TestExtractAndValidateLine_ConfiguredEndpoint_OK(t *testing.T) {
 
 func TestExtractAndValidateLine_AllowedEndpoint_OK(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	meta, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
+	meta, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
 	if err != nil {
 		t.Fatalf("unexpected error for allowed endpoint: %v", err)
 	}
@@ -1426,6 +1442,7 @@ func TestPreProcess_StreamTrue_FailsJob(t *testing.T) {
 			ID: jobID,
 			BatchSpec: openai.BatchSpec{
 				InputFileID: inputFileID,
+				Endpoint:    openai.EndpointChatCompletions,
 			},
 			BatchStatusInfo: openai.BatchStatusInfo{
 				Status: openai.BatchStatusInProgress,
@@ -1493,6 +1510,7 @@ func TestPreProcess_DuplicateCustomID_FailsJob(t *testing.T) {
 			ID: jobID,
 			BatchSpec: openai.BatchSpec{
 				InputFileID: inputFileID,
+				Endpoint:    openai.EndpointChatCompletions,
 			},
 			BatchStatusInfo: openai.BatchStatusInfo{
 				Status: openai.BatchStatusInProgress,
@@ -1563,6 +1581,7 @@ func TestPreProcess_UniqueCustomIDs_Succeeds(t *testing.T) {
 			ID: jobID,
 			BatchSpec: openai.BatchSpec{
 				InputFileID: inputFileID,
+				Endpoint:    openai.EndpointChatCompletions,
 			},
 			BatchStatusInfo: openai.BatchStatusInfo{
 				Status: openai.BatchStatusInProgress,
@@ -1641,6 +1660,7 @@ func TestPreProcess_UnregisteredModel_RejectedToErrorFile(t *testing.T) {
 			ID: jobID,
 			BatchSpec: openai.BatchSpec{
 				InputFileID: inputFileID,
+				Endpoint:    openai.EndpointChatCompletions,
 			},
 			BatchStatusInfo: openai.BatchStatusInfo{
 				Status: openai.BatchStatusInProgress,
@@ -1760,6 +1780,7 @@ func TestPreProcess_AllRequestsUnregistered_ExecuteJobCounts(t *testing.T) {
 			ID: jobID,
 			BatchSpec: openai.BatchSpec{
 				InputFileID: inputFileID,
+				Endpoint:    openai.EndpointChatCompletions,
 			},
 			BatchStatusInfo: openai.BatchStatusInfo{
 				Status: openai.BatchStatusInProgress,
@@ -1887,7 +1908,7 @@ func TestPreProcess_ReEnqueue_TruncatesStaleErrorFile(t *testing.T) {
 		JobID: jobID,
 		BatchJob: &openai.Batch{
 			ID:              jobID,
-			BatchSpec:       openai.BatchSpec{InputFileID: inputFileID},
+			BatchSpec:       openai.BatchSpec{InputFileID: inputFileID, Endpoint: openai.EndpointChatCompletions},
 			BatchStatusInfo: openai.BatchStatusInfo{Status: openai.BatchStatusInProgress},
 		},
 		TenantID: tenantID,
@@ -1981,7 +2002,7 @@ func TestPreProcess_ModelNotFound_ThenEarlySLO_PreservesErrorFile(t *testing.T) 
 		JobID: jobID,
 		BatchJob: &openai.Batch{
 			ID:              jobID,
-			BatchSpec:       openai.BatchSpec{InputFileID: inputFileID},
+			BatchSpec:       openai.BatchSpec{InputFileID: inputFileID, Endpoint: openai.EndpointChatCompletions},
 			BatchStatusInfo: openai.BatchStatusInfo{Status: openai.BatchStatusInProgress},
 		},
 		TenantID: tenantID,

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -1207,7 +1207,7 @@ func TestRunPollingLoop_GuardReEnqueueFails_FallsBackToHandleFailed(t *testing.T
 
 func TestExtractAndValidateLine_StreamTrue_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line)
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err == nil {
 		t.Fatal("expected error for stream: true, got nil")
 	}
@@ -1218,7 +1218,7 @@ func TestExtractAndValidateLine_StreamTrue_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_StreamFalse_OK(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","stream":false,"messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	meta, err := extractAndValidateLine(line)
+	meta, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err != nil {
 		t.Fatalf("unexpected error for stream: false: %v", err)
 	}
@@ -1232,7 +1232,7 @@ func TestExtractAndValidateLine_StreamFalse_OK(t *testing.T) {
 
 func TestExtractAndValidateLine_StreamOmitted_OK(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	meta, err := extractAndValidateLine(line)
+	meta, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err != nil {
 		t.Fatalf("unexpected error when stream is omitted: %v", err)
 	}
@@ -1243,7 +1243,7 @@ func TestExtractAndValidateLine_StreamOmitted_OK(t *testing.T) {
 
 func TestExtractAndValidateLine_EmptyCustomID_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line)
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err == nil {
 		t.Fatal("expected error for empty custom_id, got nil")
 	}
@@ -1254,7 +1254,7 @@ func TestExtractAndValidateLine_EmptyCustomID_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_MissingCustomID_ReturnsError(t *testing.T) {
 	line := []byte(`{"method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line)
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err == nil {
 		t.Fatal("expected error for missing custom_id, got nil")
 	}
@@ -1265,7 +1265,7 @@ func TestExtractAndValidateLine_MissingCustomID_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_MissingMethod_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line)
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err == nil {
 		t.Fatal("expected error for missing method, got nil")
 	}
@@ -1276,7 +1276,7 @@ func TestExtractAndValidateLine_MissingMethod_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_InvalidMethod_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"DELETE","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line)
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err == nil {
 		t.Fatal("expected error for invalid method, got nil")
 	}
@@ -1287,7 +1287,7 @@ func TestExtractAndValidateLine_InvalidMethod_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_MissingURL_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line)
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err == nil {
 		t.Fatal("expected error for missing url, got nil")
 	}
@@ -1298,7 +1298,7 @@ func TestExtractAndValidateLine_MissingURL_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_AbsoluteURL_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"http://evil.com","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line)
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err == nil {
 		t.Fatal("expected error for absolute url, got nil")
 	}
@@ -1309,7 +1309,7 @@ func TestExtractAndValidateLine_AbsoluteURL_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_DoubleSlashURL_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"//evil.com","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line)
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err == nil {
 		t.Fatal("expected error for protocol-relative url, got nil")
 	}
@@ -1320,7 +1320,7 @@ func TestExtractAndValidateLine_DoubleSlashURL_ReturnsError(t *testing.T) {
 
 func TestExtractAndValidateLine_NotAllowedEndpoint_ReturnsError(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"/not-allowed","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, err := extractAndValidateLine(line)
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err == nil {
 		t.Fatal("expected error for invalid endpoint, got nil")
 	}
@@ -1329,9 +1329,42 @@ func TestExtractAndValidateLine_NotAllowedEndpoint_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestExtractAndValidateLine_BatchEndpointMismatch(t *testing.T) {
+	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/embeddings","body":{"model":"embedding-model"}}` + "\n")
+	_, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/chat/completions")
+	if err == nil {
+		t.Fatal("expected error when request endpoint differs from batch endpoint")
+	}
+	if !strings.Contains(err.Error(), "does not match batch endpoint") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestExtractAndValidateLine_BatchEndpointMatch(t *testing.T) {
+	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/embeddings","body":{"model":"embedding-model"}}` + "\n")
+	if _, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "/v1/embeddings"); err != nil {
+		t.Fatalf("unexpected error when endpoints match: %v", err)
+	}
+}
+
+func TestExtractAndValidateLine_ConfiguredEndpoint_OK(t *testing.T) {
+	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/classify","body":{"model":"classifier"}}` + "\n")
+	allowlist, err := openai.NewEndpointAllowlist([]string{"/v1/classify"})
+	if err != nil {
+		t.Fatalf("NewEndpointAllowlist() unexpected error: %v", err)
+	}
+	meta, err := extractAndValidateLine(line, allowlist, "/v1/classify")
+	if err != nil {
+		t.Fatalf("unexpected error for configured endpoint: %v", err)
+	}
+	if meta.ModelID != "classifier" {
+		t.Fatalf("expected model classifier, got %s", meta.ModelID)
+	}
+}
+
 func TestExtractAndValidateLine_AllowedEndpoint_OK(t *testing.T) {
 	line := []byte(`{"custom_id":"r1","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	meta, err := extractAndValidateLine(line)
+	meta, err := extractAndValidateLine(line, openai.EndpointAllowlist{}, "")
 	if err != nil {
 		t.Fatalf("unexpected error for allowed endpoint: %v", err)
 	}

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -49,10 +49,11 @@ type endpointLimit struct {
 }
 
 type Processor struct {
-	cfg         *config.ProcessorConfig
-	processorID string
-	tokens      semaphore.Semaphore
-	wg          sync.WaitGroup
+	cfg               *config.ProcessorConfig
+	endpointAllowlist openai.EndpointAllowlist
+	processorID       string
+	tokens            semaphore.Semaphore
+	wg                sync.WaitGroup
 
 	// globalSem limits total in-flight inference requests across all workers.
 	// Fixed capacity — serves as a ceiling only.
@@ -91,19 +92,24 @@ func NewProcessor(
 	if cfg.Concurrency.Global <= 0 {
 		return nil, fmt.Errorf("global semaphore (concurrency.global=%d): %w", cfg.Concurrency.Global, semaphore.ErrCap)
 	}
+	endpointAllowlist, err := openai.NewEndpointAllowlist(cfg.ExtraEndpoints)
+	if err != nil {
+		return nil, fmt.Errorf("extra endpoints: %w", err)
+	}
 	poller := NewPoller(clients.Queue, clients.BatchDB)
 	updater := NewStatusUpdater(clients.BatchDB, clients.Status, cfg.ProgressTTLSeconds)
 	return &Processor{
-		cfg:            cfg,
-		processorID:    processorID,
-		poller:         poller,
-		updater:        updater,
-		batchDB:        clients.BatchDB,
-		event:          clients.Event,
-		inflight:       clients.InFlight,
-		inference:      clients.Inference,
-		asyncInference: clients.AsyncInference,
-		files:          newFileManager(clients.File, clients.FileDB),
+		cfg:               cfg,
+		endpointAllowlist: endpointAllowlist,
+		processorID:       processorID,
+		poller:            poller,
+		updater:           updater,
+		batchDB:           clients.BatchDB,
+		event:             clients.Event,
+		inflight:          clients.InFlight,
+		inference:         clients.Inference,
+		asyncInference:    clients.AsyncInference,
+		files:             newFileManager(clients.File, clients.FileDB),
 	}, nil
 }
 

--- a/internal/shared/openai/batch.go
+++ b/internal/shared/openai/batch.go
@@ -39,16 +39,6 @@ const (
 	EndpointModerations     Endpoint = "/v1/moderations"
 )
 
-// defaultEndpoints is the canonical set of OpenAI Batch API endpoints.
-// Declared as an array (not slice) so it cannot be appended to or resliced.
-var defaultEndpoints = [5]Endpoint{
-	EndpointResponses,
-	EndpointChatCompletions,
-	EndpointEmbeddings,
-	EndpointCompletions,
-	EndpointModerations,
-}
-
 // EndpointAllowlist reports which batch endpoints are accepted. The zero value accepts
 // exactly the OpenAI Batch API endpoints.
 type EndpointAllowlist struct {
@@ -87,12 +77,16 @@ func (a EndpointAllowlist) IsValid(endpoint string) bool {
 }
 
 func isDefaultEndpoint(endpoint Endpoint) bool {
-	for _, candidate := range defaultEndpoints {
-		if endpoint == candidate {
-			return true
-		}
+	switch endpoint {
+	case EndpointResponses,
+		EndpointChatCompletions,
+		EndpointEmbeddings,
+		EndpointCompletions,
+		EndpointModerations:
+		return true
+	default:
+		return false
 	}
-	return false
 }
 
 func validateEndpointPath(endpoint string) error {

--- a/internal/shared/openai/batch.go
+++ b/internal/shared/openai/batch.go
@@ -20,6 +20,8 @@ package openai
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -37,6 +39,82 @@ const (
 	EndpointModerations     Endpoint = "/v1/moderations"
 )
 
+// defaultEndpoints is the canonical set of OpenAI Batch API endpoints.
+// Declared as an array (not slice) so it cannot be appended to or resliced.
+var defaultEndpoints = [5]Endpoint{
+	EndpointResponses,
+	EndpointChatCompletions,
+	EndpointEmbeddings,
+	EndpointCompletions,
+	EndpointModerations,
+}
+
+// EndpointAllowlist reports which batch endpoints are accepted. The zero value accepts
+// exactly the OpenAI Batch API endpoints.
+type EndpointAllowlist struct {
+	extra map[Endpoint]struct{}
+}
+
+// NewEndpointAllowlist returns an allowlist covering the OpenAI endpoints plus extra.
+// Entries duplicating a default are ignored. Malformed entries are rejected so a
+// bad deployment config fails at startup, not per request.
+func NewEndpointAllowlist(extra []string) (EndpointAllowlist, error) {
+	var a EndpointAllowlist
+	for _, e := range extra {
+		if err := validateEndpointPath(e); err != nil {
+			return EndpointAllowlist{}, fmt.Errorf("endpoint %q: %w", e, err)
+		}
+		ep := Endpoint(e)
+		if isDefaultEndpoint(ep) {
+			continue
+		}
+		if a.extra == nil {
+			a.extra = make(map[Endpoint]struct{}, len(extra))
+		}
+		a.extra[ep] = struct{}{}
+	}
+	return a, nil
+}
+
+// IsValid reports whether endpoint is accepted by this allowlist
+func (a EndpointAllowlist) IsValid(endpoint string) bool {
+	ep := Endpoint(endpoint)
+	if isDefaultEndpoint(ep) {
+		return true
+	}
+	_, ok := a.extra[ep]
+	return ok
+}
+
+func isDefaultEndpoint(endpoint Endpoint) bool {
+	for _, candidate := range defaultEndpoints {
+		if endpoint == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func validateEndpointPath(endpoint string) error {
+	if endpoint == "" {
+		return errors.New("path cannot be empty")
+	}
+	if endpoint[0] != '/' || len(endpoint) > 1 && endpoint[1] == '/' {
+		return errors.New("must be an absolute path beginning with exactly one slash")
+	}
+	if strings.ContainsAny(endpoint, "?#") {
+		return errors.New("must not contain a query string or fragment")
+	}
+	parsed, err := url.ParseRequestURI(endpoint)
+	if err != nil {
+		return fmt.Errorf("must be a valid URL path: %w", err)
+	}
+	if parsed.Path != endpoint || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("must not contain a query string, fragment, or escaped path")
+	}
+	return nil
+}
+
 func (e Endpoint) String() string {
 	return string(e)
 }
@@ -44,16 +122,7 @@ func (e Endpoint) String() string {
 // IsValidEndpoint reports whether the given endpoint is one of the supported
 // Batch API endpoints.
 func IsValidEndpoint(endpoint string) bool {
-	switch Endpoint(endpoint) {
-	case EndpointResponses,
-		EndpointChatCompletions,
-		EndpointEmbeddings,
-		EndpointCompletions,
-		EndpointModerations:
-		return true
-	default:
-		return false
-	}
+	return (EndpointAllowlist{}).IsValid(endpoint)
 }
 
 type BatchStatus string
@@ -293,6 +362,11 @@ type OutputExpiresAfter struct {
 }
 
 func (r *CreateBatchRequest) Validate() error {
+	return r.ValidateWithEndpointAllowlist(EndpointAllowlist{})
+}
+
+// ValidateWithEndpointAllowlist validates the request using the supplied endpoint allowlist.
+func (r *CreateBatchRequest) ValidateWithEndpointAllowlist(allowlist EndpointAllowlist) error {
 	if r.CompletionWindow == "" {
 		return errors.New("completion_window is required")
 	}
@@ -305,7 +379,7 @@ func (r *CreateBatchRequest) Validate() error {
 		return errors.New("endpoint is required")
 	}
 
-	if !IsValidEndpoint(r.Endpoint.String()) {
+	if !allowlist.IsValid(r.Endpoint.String()) {
 		return errors.New("invalid endpoint: " + string(r.Endpoint))
 	}
 

--- a/internal/shared/openai/batch_test.go
+++ b/internal/shared/openai/batch_test.go
@@ -29,6 +29,60 @@ func validRequest() CreateBatchRequest {
 	}
 }
 
+func TestEndpointAllowlist(t *testing.T) {
+	t.Run("defaults and extensions", func(t *testing.T) {
+		defaults := EndpointAllowlist{}
+		for _, endpoint := range defaultEndpoints {
+			if !defaults.IsValid(endpoint.String()) {
+				t.Errorf("zero-value allowlist rejected default endpoint %q", endpoint)
+			}
+		}
+		if defaults.IsValid("/v1/classify") {
+			t.Error("zero-value allowlist accepted an unconfigured extension")
+		}
+
+		allowlist, err := NewEndpointAllowlist([]string{"/v1/classify", "/v1/pooling", "/v1/classify", EndpointChatCompletions.String()})
+		if err != nil {
+			t.Fatalf("NewEndpointAllowlist() unexpected error: %v", err)
+		}
+		for _, endpoint := range []string{EndpointChatCompletions.String(), "/v1/classify", "/v1/pooling"} {
+			if !allowlist.IsValid(endpoint) {
+				t.Errorf("configured allowlist rejected endpoint %q", endpoint)
+			}
+		}
+		if allowlist.IsValid("/v1/unconfigured") {
+			t.Error("configured allowlist accepted an unconfigured extension")
+		}
+	})
+
+	t.Run("invalid paths", func(t *testing.T) {
+		for _, endpoint := range []string{"", "v1/classify", "//example.com/v1/classify", "/v1/classify?mode=test", "/v1/classify#fragment", "/v1/%63lassify"} {
+			if _, err := NewEndpointAllowlist([]string{endpoint}); err == nil {
+				t.Errorf("NewEndpointAllowlist(%q) expected error", endpoint)
+			}
+		}
+	})
+}
+
+func TestValidateWithEndpointAllowlist(t *testing.T) {
+	req := validRequest()
+	req.Endpoint = "/v1/classify"
+	if err := req.Validate(); err == nil {
+		t.Error("Validate() accepted an extension without an allowlist")
+	}
+	allowlist, err := NewEndpointAllowlist([]string{"/v1/classify"})
+	if err != nil {
+		t.Fatalf("NewEndpointAllowlist() unexpected error: %v", err)
+	}
+	if err := req.ValidateWithEndpointAllowlist(allowlist); err != nil {
+		t.Errorf("ValidateWithEndpointAllowlist() rejected configured extension: %v", err)
+	}
+	req.Endpoint = "/v1/pooling"
+	if err := req.ValidateWithEndpointAllowlist(allowlist); err == nil {
+		t.Error("ValidateWithEndpointAllowlist() accepted unconfigured extension")
+	}
+}
+
 func TestValidate_MetadataTooManyKeys(t *testing.T) {
 	req := validRequest()
 	req.Metadata = make(map[string]string, 17)

--- a/internal/shared/openai/batch_test.go
+++ b/internal/shared/openai/batch_test.go
@@ -32,7 +32,13 @@ func validRequest() CreateBatchRequest {
 func TestEndpointAllowlist(t *testing.T) {
 	t.Run("defaults and extensions", func(t *testing.T) {
 		defaults := EndpointAllowlist{}
-		for _, endpoint := range defaultEndpoints {
+		for _, endpoint := range []Endpoint{
+			EndpointResponses,
+			EndpointChatCompletions,
+			EndpointEmbeddings,
+			EndpointCompletions,
+			EndpointModerations,
+		} {
 			if !defaults.IsValid(endpoint.String()) {
 				t.Errorf("zero-value allowlist rejected default endpoint %q", endpoint)
 			}

--- a/pkg/clients/inference/inference_client_test.go
+++ b/pkg/clients/inference/inference_client_test.go
@@ -240,36 +240,42 @@ func testGenerate(t *testing.T) {
 		}
 	})
 
-	t.Run("should use endpoint from request", func(t *testing.T) {
-		endpoint := ""
-		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			endpoint = r.URL.Path
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "test"})
-		}))
-		t.Cleanup(testServer.Close)
+	t.Run("should preserve configured non-default endpoint", func(t *testing.T) {
+		for _, endpoint := range []string{"/v1/classify", "/v1/pooling"} {
+			t.Run(endpoint, func(t *testing.T) {
+				var receivedPath string
+				testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					receivedPath = r.URL.Path
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "test"})
+				}))
+				t.Cleanup(testServer.Close)
 
-		client, err := NewInferenceClient(&HTTPClientConfig{
-			BaseURL: testServer.URL,
-			Timeout: 10 * time.Second,
-		}, testLogger(t))
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+				client, err := NewInferenceClient(&HTTPClientConfig{
+					BaseURL: testServer.URL,
+					Timeout: 10 * time.Second,
+				}, testLogger(t))
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
 
-		req := &GenerateRequest{
-			RequestID: "test",
-			Endpoint:  "/v1/chat/completions",
-			Params: map[string]interface{}{
-				"messages": []map[string]interface{}{
-					{"role": "user", "content": "test"},
-				},
-			},
-		}
+				req := &GenerateRequest{
+					RequestID: "test",
+					Endpoint:  endpoint,
+					Params: map[string]interface{}{
+						"model": "classifier",
+						"input": "test",
+					},
+				}
 
-		_, _ = client.Generate(context.Background(), req)
-		if endpoint != "/v1/chat/completions" {
-			t.Errorf("got endpoint %v, want %v", endpoint, "/v1/chat/completions")
+				_, genErr := client.Generate(context.Background(), req)
+				if genErr != nil {
+					t.Fatalf("Generate() error = %v", genErr)
+				}
+				if receivedPath != endpoint {
+					t.Errorf("got endpoint %q, want configured endpoint %q", receivedPath, endpoint)
+				}
+			})
 		}
 	})
 

--- a/test/integration/setup_test.go
+++ b/test/integration/setup_test.go
@@ -101,7 +101,10 @@ func newTestServer(t *testing.T) *testServer {
 
 	mux := http.NewServeMux()
 	fileHandler := file.NewFileAPIHandler(config, clients)
-	batchHandler := batch.NewBatchAPIHandler(config, clients)
+	batchHandler, err := batch.NewBatchAPIHandler(config, clients)
+	if err != nil {
+		t.Fatalf("NewBatchAPIHandler: %v", err)
+	}
 	middlewares := []common.RouteMiddleware{
 		middleware.Recovery,
 		middleware.NewRequestMiddleware(config),


### PR DESCRIPTION
## Why is this PR needed?

Batch Gateway currently validates batch endpoints against a fixed list of OpenAI Batch API endpoints. OpenAI-compatible inference backends may expose other batch-capable endpoints; for example, NVIDIA Dynamo supports `/v1/classify` and `/v1/pooling`, but Batch Gateway rejects batches using those endpoints before requests reach the backend.

This PR preserves the OpenAI-only default while allowing operators to explicitly enable deployment-specific endpoints.

## What does this PR do?

- Adds a reusable endpoint allowlist containing the standard OpenAI Batch API endpoints plus explicitly configured extensions.
- Validates configured paths at startup and rejects absolute URLs, query strings, fragments, escaped paths, and other unsafe values.
- Adds standalone API-server configuration under `batch_api.extra_endpoints` and processor configuration under `extra_endpoints`.
- Adds shared Helm configuration under `global.extraEndpoints`, with component-specific API-server and processor overrides.
- Documents a processor-first rollout: configure processor endpoints, wait for the processor rollout, enable them globally, then remove the processor override so it inherits the global value.
- Applies the same allowlist during batch creation and processor JSONL preprocessing.
- Requires every request URL in an input JSONL file to exactly match the endpoint declared on its batch.
- Preserves configured endpoints unchanged through synchronous and asynchronous inference dispatch.
- Preserves existing OpenAI-only behavior when no additional endpoints are configured.

Example Helm configuration:

```yaml
global:
  extraEndpoints:
    - /v1/classify
    - /v1/pooling
```

## How was this tested?

- [x] Unit tests added/updated/verified
  - Covered default, configured, unconfigured, malformed, and unsafe endpoints.
  - Covered API-server and processor configuration, batch creation, JSONL validation, and exact request-to-batch endpoint matching.
  - Added an inference-client regression proving `/v1/classify` and `/v1/pooling` reach `InferenceHTTPClient.Generate` unchanged.
  - Full unit suite: `1173 passed, 0 failed, 17 skipped`.
- [x] Integration/e2e tests added/updated/verified
  - Local kind E2E suite: `66 passed, 0 failed, 4 skipped`.
  - Added Helm rendering tests for global inheritance, component overrides, and empty endpoint lists.
- [x] Manual testing performed
  - Ran `helm lint` and verified the rendered API-server and processor ConfigMaps.
  - Validated a processor-first rollout against a real Dynamo deployment using `cross-encoder/nli-MiniLM2-L6-H768`.
  - Before configuration, `/v1/classify` and `/v1/pooling` batch creation returned HTTP 400.
  - After configuration, batches for both endpoints completed with `total=1, completed=1, failed=0`; output records returned HTTP 200 with no error, and Dynamo logs confirmed both paths arrived unchanged.
  - Restored the Helm release and GPU deployment and removed the temporary namespace and SSH tunnel after validation.

Detailed Dynamo commands, topology, results, and cleanup evidence are recorded in [this PR comment](https://github.com/llm-d/llm-d-batch-gateway/pull/665#issuecomment-5555606756).

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

#656 
