### PR TITLE
test(e2e): cover composed batch dispatch gate

### DIFF
--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -816,6 +816,14 @@ install_vllm_sim() {
     local sim_model="$2"
     local time_to_first_token_ms="$3"
     local inter_token_latency_ms="$4"
+    local served_model_name="${sim_model}"
+    local vllm_extra_args="--reasoning-parser none --tool-call-parser none"
+
+    if [[ "${ENABLE_DISPATCHER}" == "true" && "${sim_model}" == "${VLLM_SIM_MODEL}" ]]; then
+        # The composed dispatch-gate E2E routes this dedicated model alias to sim-pool-gate.
+        served_model_name=""
+        vllm_extra_args="--served-model-name ${sim_model} sim-model-gate ${vllm_extra_args}"
+    fi
 
     step "Installing vllm-vcr '${sim_name}' (model: ${sim_model}, ttft=${time_to_first_token_ms}ms, itl=${inter_token_latency_ms}ms)..."
 
@@ -843,9 +851,9 @@ spec:
         - name: MODEL
           value: ${VLLM_SIM_HF_MODEL}
         - name: SERVED_MODEL_NAME
-          value: ${sim_model}
+          value: "${served_model_name}"
         - name: VLLM_EXTRA_ARGS
-          value: "--reasoning-parser none --tool-call-parser none"
+          value: "${vllm_extra_args}"
         - name: MOCK_TTFT_MS
           value: "${time_to_first_token_ms}"
         - name: MOCK_ITL_MS

--- a/test/e2e/dispatcher/processor-async-values.yaml
+++ b/test/e2e/dispatcher/processor-async-values.yaml
@@ -6,5 +6,7 @@ processor:
       models:
         sim-model:
           inferencePoolName: "sim-pool"
+        sim-model-gate:
+          inferencePoolName: "sim-pool-gate"
         sim-model-inject:
           inferencePoolName: "sim-pool-inject"

--- a/test/e2e/dispatcher_test.go
+++ b/test/e2e/dispatcher_test.go
@@ -44,6 +44,7 @@ var (
 	gatePool              = "sim-pool-gate"
 	gateReqQueue          = "llm-d-async:requests:" + gatePool
 	gateResultQueue       = "llm-d-async:results:" + gatePool
+	gateModel             = "sim-model-gate"
 	dispatchGateBudgetKey = "dispatch-gate-budget"
 
 	scrapePool        = "sim-pool-scrape"
@@ -149,6 +150,9 @@ func TestDispatcher(t *testing.T) {
 	})
 	t.Run("DispatchGate", func(t *testing.T) {
 		testDispatcherRedisGate(t, rdb)
+	})
+	t.Run("BatchAPIDispatchGate", func(t *testing.T) {
+		testBatchAPIDispatchGate(t, rdb)
 	})
 	t.Run("EndpointScrapeGate", func(t *testing.T) {
 		testDispatcherEndpointScrapeGate(t, rdb)
@@ -519,6 +523,171 @@ func testDispatcherRedisGate(t *testing.T, rdb *redis.Client) {
 			return
 		}
 		t.Logf("Skipped stale result %s", result.ID)
+	}
+}
+
+func testBatchAPIDispatchGate(t *testing.T, rdb *redis.Client) {
+	ctx := context.Background()
+	queueDepth, err := rdb.ZCard(ctx, gateReqQueue).Result()
+	if err != nil {
+		t.Fatalf("read initial dispatch queue: %v", err)
+	}
+	if queueDepth != 0 {
+		t.Fatalf("gated queue is not clean before test: depth=%d", queueDepth)
+	}
+
+	previousBudget, err := rdb.Get(ctx, dispatchGateBudgetKey).Result()
+	budgetExisted := err == nil
+	if err != nil && err != redis.Nil {
+		t.Fatalf("read prior dispatch gate budget: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := rdb.Set(cleanupCtx, dispatchGateBudgetKey, "1.0", 0).Err(); err != nil {
+			t.Errorf("cleanup: open dispatch gate: %v", err)
+		} else {
+			deadline := time.Now().Add(5 * time.Second)
+			var depth int64
+			for time.Now().Before(deadline) {
+				var depthErr error
+				depth, depthErr = rdb.ZCard(cleanupCtx, gateReqQueue).Result()
+				if depthErr != nil {
+					t.Errorf("cleanup: read dispatch queue: %v", depthErr)
+					break
+				}
+				if depth == 0 {
+					break
+				}
+				time.Sleep(200 * time.Millisecond)
+			}
+			if depth != 0 {
+				t.Errorf("cleanup: gated queue did not drain after opening: depth=%d", depth)
+			}
+		}
+
+		if budgetExisted {
+			if err := rdb.Set(cleanupCtx, dispatchGateBudgetKey, previousBudget, 0).Err(); err != nil {
+				t.Errorf("cleanup: restore dispatch gate budget: %v", err)
+			}
+		} else if err := rdb.Del(cleanupCtx, dispatchGateBudgetKey).Err(); err != nil {
+			t.Errorf("cleanup: remove dispatch gate budget: %v", err)
+		}
+	})
+
+	if err := rdb.Set(ctx, dispatchGateBudgetKey, "0.0", 0).Err(); err != nil {
+		t.Fatalf("close dispatch gate: %v", err)
+	}
+	t.Log("Gate closed (budget=0.0)")
+
+	// The Redis gate polls every 500ms. Wait for it to observe the closed budget
+	// before creating the batch so the request cannot race through the gate.
+	time.Sleep(2 * time.Second)
+
+	before := getSimStats(t, testSimService)
+	if before.Running != 0 || before.Waiting != 0 {
+		t.Fatalf("simulator is not idle before test: running=%d waiting=%d", before.Running, before.Waiting)
+	}
+	const customID = "batch-api-gate-1"
+	jsonl := fmt.Sprintf(
+		`{"custom_id":"%s","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"Hello composed gate"}]}}`,
+		customID, gateModel)
+	fileID := mustCreateFile(t, fmt.Sprintf("dispatcher-batch-api-gate-%s.jsonl", testRunID), jsonl)
+	batchID := mustCreateBatch(t, fileID)
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		queueDepth, err = rdb.ZCard(ctx, gateReqQueue).Result()
+		if err != nil {
+			t.Fatalf("read dispatch queue: %v", err)
+		}
+		if queueDepth > 0 {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if queueDepth == 0 {
+		t.Fatalf("batch request did not appear in gated queue within 30s")
+	}
+	// Keep the gate closed across several Async poll intervals, then re-check the
+	// queue and the engine's authoritative received counter.
+	time.Sleep(2 * time.Second)
+	queueDepth, err = rdb.ZCard(ctx, gateReqQueue).Result()
+	if err != nil {
+		t.Fatalf("re-read dispatch queue: %v", err)
+	}
+	if queueDepth != 1 {
+		t.Fatalf("gated queue depth = %d, want 1 while budget is zero", queueDepth)
+	}
+
+	batch, err := newClient().Batches.Get(ctx, batchID)
+	if err != nil {
+		t.Fatalf("retrieve gated batch: %v", err)
+	}
+	if terminalBatchStatuses[batch.Status] {
+		t.Fatalf("batch reached terminal status %q while dispatch gate was closed", batch.Status)
+	}
+	if batch.RequestCounts.Total != 1 {
+		t.Fatalf("gated batch total requests = %d, want 1", batch.RequestCounts.Total)
+	}
+	if batch.RequestCounts.Completed != 0 || batch.RequestCounts.Failed != 0 {
+		t.Fatalf("gated batch counts = completed:%d failed:%d, want 0 and 0",
+			batch.RequestCounts.Completed, batch.RequestCounts.Failed)
+	}
+
+	gated := getSimStats(t, testSimService)
+	if gated.RequestsReceived != before.RequestsReceived {
+		t.Fatalf("inference received %d request(s) while gate was closed, want 0",
+			gated.RequestsReceived-before.RequestsReceived)
+	}
+	t.Logf("Batch %s is %s with queue depth %d; inference received no request", batchID, batch.Status, queueDepth)
+
+	if err := rdb.Set(ctx, dispatchGateBudgetKey, "1.0", 0).Err(); err != nil {
+		t.Fatalf("open dispatch gate: %v", err)
+	}
+	t.Log("Gate opened (budget=1.0)")
+
+	finalBatch, results := waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusCompleted)
+	if finalBatch.RequestCounts.Total != 1 {
+		t.Errorf("total requests = %d, want 1", finalBatch.RequestCounts.Total)
+	}
+	if finalBatch.RequestCounts.Completed != 1 {
+		t.Errorf("completed requests = %d, want 1", finalBatch.RequestCounts.Completed)
+	}
+	if finalBatch.RequestCounts.Failed != 0 {
+		t.Errorf("failed requests = %d, want 0", finalBatch.RequestCounts.Failed)
+	}
+	if results == nil {
+		t.Fatal("expected batch results")
+	}
+	if results.OutputLines != 1 || results.ErrorLines != 0 {
+		t.Fatalf("result lines = output:%d error:%d, want 1 and 0", results.OutputLines, results.ErrorLines)
+	}
+
+	var output batchResultLine
+	if err := json.Unmarshal([]byte(results.OutputBody), &output); err != nil {
+		t.Fatalf("decode batch output: %v", err)
+	}
+	if output.CustomID != customID {
+		t.Errorf("output custom_id = %q, want %q", output.CustomID, customID)
+	}
+
+	after := getSimStats(t, testSimService)
+	if got := after.RequestsReceived - before.RequestsReceived; got != 1 {
+		t.Errorf("inference requests received = %d, want exactly 1", got)
+	}
+	if got := after.RequestsCompleted - before.RequestsCompleted; got != 1 {
+		t.Errorf("inference requests completed = %d, want exactly 1", got)
+	}
+	if got := after.RequestsFailed - before.RequestsFailed; got != 0 {
+		t.Errorf("inference requests failed = %d, want 0", got)
+	}
+	if got := after.RequestsAborted - before.RequestsAborted; got != 0 {
+		t.Errorf("inference requests aborted = %d, want 0", got)
+	}
+	if after.Running != 0 || after.Waiting != 0 {
+		t.Errorf("simulator is not idle after test: running=%d waiting=%d", after.Running, after.Waiting)
 	}
 }
 

--- a/test/e2e/dispatcher_test.go
+++ b/test/e2e/dispatcher_test.go
@@ -542,29 +542,31 @@ func testBatchAPIDispatchGate(t *testing.T, rdb *redis.Client) {
 		t.Fatalf("read prior dispatch gate budget: %v", err)
 	}
 	t.Cleanup(func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
 		defer cancel()
 
 		if err := rdb.Set(cleanupCtx, dispatchGateBudgetKey, "1.0", 0).Err(); err != nil {
 			t.Errorf("cleanup: open dispatch gate: %v", err)
-		} else {
-			deadline := time.Now().Add(5 * time.Second)
-			var depth int64
-			for time.Now().Before(deadline) {
-				var depthErr error
-				depth, depthErr = rdb.ZCard(cleanupCtx, gateReqQueue).Result()
-				if depthErr != nil {
-					t.Errorf("cleanup: read dispatch queue: %v", depthErr)
-					break
-				}
-				if depth == 0 {
-					break
-				}
-				time.Sleep(200 * time.Millisecond)
+			return
+		}
+
+		deadline := time.Now().Add(30 * time.Second)
+		var depth int64
+		for time.Now().Before(deadline) {
+			var depthErr error
+			depth, depthErr = rdb.ZCard(cleanupCtx, gateReqQueue).Result()
+			if depthErr != nil {
+				t.Errorf("cleanup: read dispatch queue: %v", depthErr)
+				return
 			}
-			if depth != 0 {
-				t.Errorf("cleanup: gated queue did not drain after opening: depth=%d", depth)
+			if depth == 0 {
+				break
 			}
+			time.Sleep(200 * time.Millisecond)
+		}
+		if depth != 0 {
+			t.Errorf("cleanup: gated queue did not drain after opening: depth=%d; leaving budget at 1.0", depth)
+			return
 		}
 
 		if budgetExisted {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -716,6 +716,39 @@ func deleteE2ECurlPod(t *testing.T) {
 
 // ── Simulator control API helpers ────────────────────────────────────────
 
+type simStats struct {
+	RequestsReceived  int64 `json:"requests_received"`
+	RequestsCompleted int64 `json:"requests_completed"`
+	RequestsFailed    int64 `json:"requests_failed"`
+	RequestsAborted   int64 `json:"requests_aborted"`
+	Running           int64 `json:"running"`
+	Waiting           int64 `json:"waiting"`
+}
+
+func getSimStats(t *testing.T, simService string) simStats {
+	t.Helper()
+
+	ensureE2ECurlPod(t)
+
+	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:%s/stats", simService, testNamespace, testSimControlPort)
+	out, err := exec.Command("kubectl", "exec",
+		"-n", testNamespace,
+		e2eCurlPod,
+		"--",
+		"curl", "-sS", "--fail", "--max-time", "10",
+		url,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("GET %s failed: %v\n%s", url, err, out)
+	}
+
+	var stats simStats
+	if err := json.Unmarshal(out, &stats); err != nil {
+		t.Fatalf("decode %s response: %v\n%s", url, err, out)
+	}
+	return stats
+}
+
 // tryPatchEngineConfig sends a PATCH to the vllm-vcr control API of the given
 // simulator service via a curl pod running in the cluster. body is a JSON
 // object of config fields (see the vllm-vcr "Runtime control API" docs); the


### PR DESCRIPTION
## Why is this PR needed?

The existing test exercised llm-d-async’s Producer directly. This test verifies the real consumer path: Files API → Batch API → batch processor → llm-d-async dispatch gate → inference

## What does this PR do?

Adds the missing composed dispatch-gate E2E tracked under #657.

## How was this tested?

- Focused composed dispatch-gate E2E passed
- Full dispatcher E2E passed: 12 passed, 0 failed
- `make test` passed: 1,156 passed, 0 failed, 17 skipped
- `gofmt`, shell syntax, and `git diff --check` passed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Related to #657
