### PR TITLE
test(e2e): resolve the objective the way the processor does

### DIFF
--- a/test/e2e/flow_control_test.go
+++ b/test/e2e/flow_control_test.go
@@ -45,6 +45,7 @@ import (
 	"time"
 
 	"github.com/openai/openai-go/v3"
+	"gopkg.in/yaml.v3"
 )
 
 func testFlowControl(t *testing.T) {
@@ -806,21 +807,47 @@ func scrapeEPPMetrics(t *testing.T, deployment string) string {
 	return string(out)
 }
 
+// processorObjectiveConfig is the subset of the processor config.yaml that
+// decides which inference objective a model gets. The precedence in
+// inferenceObjectiveFor mirrors config.ProcessorConfig.InferenceObjectiveFor.
+type processorObjectiveConfig struct {
+	DispatchMode  string `yaml:"dispatch_mode"`
+	AsyncDispatch struct {
+		Models map[string]struct {
+			InferenceObjective string `yaml:"inference_objective"`
+		} `yaml:"models"`
+	} `yaml:"async_dispatch"`
+	GlobalInferenceGateway *struct {
+		InferenceObjective string `yaml:"inference_objective"`
+	} `yaml:"global_inference_gateway"`
+	ModelGateways map[string]struct {
+		InferenceObjective string `yaml:"inference_objective"`
+	} `yaml:"model_gateways"`
+}
+
+func (c *processorObjectiveConfig) inferenceObjectiveFor(model string) string {
+	if c.DispatchMode == "async" {
+		return c.AsyncDispatch.Models[model].InferenceObjective
+	}
+	if c.GlobalInferenceGateway != nil {
+		return c.GlobalInferenceGateway.InferenceObjective
+	}
+	return c.ModelGateways[model].InferenceObjective
+}
+
 // getProcessorConfigObjective reads the deployed processor ConfigMap and
-// returns the inferenceObjective value for the given model.
+// returns the inference objective the processor resolves for the given model.
 func getProcessorConfigObjective(t *testing.T, model string) string {
 	t.Helper()
 
 	cmName := fmt.Sprintf("%s-processor-config", testHelmRelease)
 	cm := kubectlGetConfigMap(t, cmName)
 
-	pattern := regexp.MustCompile(fmt.Sprintf(`(?m)"?%s"?:\s*\n(?:.*\n)*?\s+inference_objective:\s*"?([^"\s]+)"?`, regexp.QuoteMeta(model)))
-	match := pattern.FindStringSubmatch(cm)
-	if match == nil {
-		t.Logf("inferenceObjective not found for model %q in ConfigMap (may use global default)", model)
-		return ""
+	var cfg processorObjectiveConfig
+	if err := yaml.Unmarshal([]byte(cm), &cfg); err != nil {
+		t.Fatalf("failed to parse processor ConfigMap %s: %v", cmName, err)
 	}
-	return strings.TrimSpace(match[1])
+	return cfg.inferenceObjectiveFor(model)
 }
 
 // resolveExpectedObjective returns the inference objective value that the


### PR DESCRIPTION
The InferenceObjectiveHeader e2e test only found `inference_objective` under a `model_gateways.<model>` block. With the objective on `global_inference_gateway` it read back empty and failed while the processor was sending the header fine.

The helper now parses the ConfigMap and applies the processor's own precedence (async models, global gateway, per-model gateway).

Notes
- Importing `internal/processor/config` from the e2e module pulls the inference client's aws/pgx/otel deps into `test/e2e/go.mod` (~50 indirect entries), so the four relevant fields are mirrored in a small local struct instead.
- Checked against `helm template` output for both `ci/values-flow-control.yaml` (global) and `ci/values-model-gateways.yaml` (per-model).

Fixes #667
